### PR TITLE
Treat blank section content as no-op

### DIFF
--- a/CoffeeTalk.Core/Services/CollaborativeMarkdownDocument.cs
+++ b/CoffeeTalk.Core/Services/CollaborativeMarkdownDocument.cs
@@ -86,8 +86,7 @@ public class CollaborativeMarkdownDocument
 
     public void InsertAfterHeading(string? headingText, string? content)
     {
-        if (string.IsNullOrWhiteSpace(headingText)) return;
-        content ??= "";
+        if (string.IsNullOrWhiteSpace(headingText) || string.IsNullOrWhiteSpace(content)) return;
         lock (_lock)
         {
             var doc = _content.ToString();
@@ -113,8 +112,7 @@ public class CollaborativeMarkdownDocument
     // Replace the entire content under a heading until the next heading, or append if not exists
     public void ReplaceSection(string? headingText, string? content)
     {
-        if (string.IsNullOrWhiteSpace(headingText)) return;
-        content ??= "";
+        if (string.IsNullOrWhiteSpace(headingText) || string.IsNullOrWhiteSpace(content)) return;
         lock (_lock)
         {
             var doc = _content.ToString();

--- a/CoffeeTalk.Tests/CollaborativeMarkdownDocumentTests.cs
+++ b/CoffeeTalk.Tests/CollaborativeMarkdownDocumentTests.cs
@@ -60,6 +60,36 @@ public class CollaborativeMarkdownDocumentTests
         Assert.Equal(1, count);
     }
 
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void InsertAfterHeading_ShouldPreserveContent_WhenInsertedContentIsBlank(string? insertedContent)
+    {
+        var doc = new CollaborativeMarkdownDocument();
+        doc.Restore("## Details\n\nExisting content.\n\n");
+        var before = doc.GetContent();
+
+        doc.InsertAfterHeading("Details", insertedContent);
+
+        Assert.Equal(before, doc.GetContent());
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ReplaceSection_ShouldPreserveContent_WhenReplacementContentIsBlank(string? replacementContent)
+    {
+        var doc = new CollaborativeMarkdownDocument();
+        doc.Restore("## Details\n\nExisting content.\n\n## Next\n\nNext content.\n\n");
+        var before = doc.GetContent();
+
+        doc.ReplaceSection("Details", replacementContent);
+
+        Assert.Equal(before, doc.GetContent());
+    }
+
     [Fact]
     public void Restore_ShouldRevertContent()
     {


### PR DESCRIPTION
## Summary\n- Treat null, empty, and whitespace content as no-ops in InsertAfterHeading and ReplaceSection\n- Add regression coverage proving existing document content is preserved\n\n## Tests\n- dotnet test CoffeeTalk.Tests/CoffeeTalk.Tests.csproj --no-restore --nologo