### PR TITLE
Add safe CoffeeTalk application data paths

### DIFF
--- a/CoffeeTalk.Core/Models/AppSettings.cs
+++ b/CoffeeTalk.Core/Models/AppSettings.cs
@@ -41,6 +41,7 @@ public class PersistedAppSettings
     public OrchestratorConfig? Orchestrator { get; set; }
     public EditorConfig? Editor { get; set; }
     public DynamicPersonasConfig? DynamicPersonas { get; set; }
+    public ToolsConfig? Tools { get; set; }
 }
 
 public class PersistedLlmProviderConfig

--- a/CoffeeTalk.Core/Services/AgentDataExtractor.cs
+++ b/CoffeeTalk.Core/Services/AgentDataExtractor.cs
@@ -11,13 +11,15 @@ public class AgentDataExtractor
     private readonly AIAgent _agent;
     private readonly StructuredDataConfig _config;
     private readonly CollaborativeMarkdownDocument _doc;
+    private readonly IApplicationDataPathResolver _paths;
  private readonly System.Diagnostics.TextWriterTraceListener? _tracer;
 
- public AgentDataExtractor(AIAgent agent, StructuredDataConfig config, CollaborativeMarkdownDocument doc)
+ public AgentDataExtractor(AIAgent agent, StructuredDataConfig config, CollaborativeMarkdownDocument doc, IApplicationDataPathResolver? paths = null)
  {
      _agent = agent;
      _config = config;
      _doc = doc;
+     _paths = paths ?? new ApplicationDataPathResolver();
      // Use Trace for logging without external dependencies
      _tracer = new System.Diagnostics.TextWriterTraceListener(System.Console.Error);
      System.Diagnostics.Trace.Listeners.Add(_tracer);
@@ -66,7 +68,9 @@ Based on the schema description '{_config.SchemaDescription}', extract the data 
 
             var json = CleanJson(response.ToString());
 
-            await File.WriteAllTextAsync(_config.OutputFile, json);
+            var outputPath = _paths.ResolveDataPath(_config.OutputFile, "data.json");
+            Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+            await File.WriteAllTextAsync(outputPath, json);
         }
         catch (Exception ex)
         {

--- a/CoffeeTalk.Core/Services/ApplicationDataPathResolver.cs
+++ b/CoffeeTalk.Core/Services/ApplicationDataPathResolver.cs
@@ -1,0 +1,52 @@
+namespace CoffeeTalk.Services;
+
+public interface IApplicationDataPathResolver
+{
+    string RootDirectory { get; }
+    string ConfigurationFilePath { get; }
+    string ResolveDataPath(string? path, string defaultFileName);
+    string ResolveExportPath(string? path, string defaultFileName);
+}
+
+public sealed class ApplicationDataPathResolver : IApplicationDataPathResolver
+{
+    private readonly string _exportDirectory;
+
+    public ApplicationDataPathResolver(string? rootDirectory = null)
+    {
+        RootDirectory = Path.GetFullPath(rootDirectory ?? Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "CoffeeTalk"));
+        _exportDirectory = Path.Combine(RootDirectory, "exports");
+        ConfigurationFilePath = Path.Combine(RootDirectory, "appsettings.json");
+    }
+
+    public string RootDirectory { get; }
+    public string ConfigurationFilePath { get; }
+
+    public string ResolveDataPath(string? path, string defaultFileName) =>
+        ResolveWithin(RootDirectory, path, defaultFileName);
+
+    public string ResolveExportPath(string? path, string defaultFileName) =>
+        ResolveWithin(_exportDirectory, path, defaultFileName);
+
+    private static string ResolveWithin(string root, string? path, string defaultFileName)
+    {
+        if (string.IsNullOrWhiteSpace(defaultFileName))
+            throw new ArgumentException("A default file name is required.", nameof(defaultFileName));
+
+        var relativePath = string.IsNullOrWhiteSpace(path) ? defaultFileName : path;
+        if (Path.IsPathRooted(relativePath))
+            throw new UnauthorizedAccessException("Rooted paths are not allowed.");
+
+        var fullRoot = Path.GetFullPath(root);
+        var fullPath = Path.GetFullPath(Path.Combine(fullRoot, relativePath));
+        if (!fullPath.Equals(fullRoot, StringComparison.Ordinal) &&
+            !fullPath.StartsWith(fullRoot + Path.DirectorySeparatorChar, StringComparison.Ordinal))
+        {
+            throw new UnauthorizedAccessException("Path escapes the CoffeeTalk data directory.");
+        }
+
+        return fullPath;
+    }
+}

--- a/CoffeeTalk.Core/Services/CollaborativeMarkdownDocument.cs
+++ b/CoffeeTalk.Core/Services/CollaborativeMarkdownDocument.cs
@@ -7,10 +7,11 @@ public class CollaborativeMarkdownDocument
 {
     private readonly StringBuilder _content = new();
     private readonly object _lock = new();
+    private readonly IApplicationDataPathResolver _paths;
 
-    public CollaborativeMarkdownDocument()
+    public CollaborativeMarkdownDocument(IApplicationDataPathResolver? paths = null)
     {
-        // Start empty
+        _paths = paths ?? new ApplicationDataPathResolver();
     }
 
     public string GetContent()
@@ -258,16 +259,8 @@ public class CollaborativeMarkdownDocument
             contentToWrite = _content.ToString();
         }
 
-        var safeFileName = string.IsNullOrWhiteSpace(path) ? "conversation.md" : Path.GetFileName(path);
-        if (string.IsNullOrEmpty(safeFileName))
-            safeFileName = "conversation.md";
-        var safeBase = Path.GetFullPath(Directory.GetCurrentDirectory());
-        var fullPath = Path.GetFullPath(Path.Combine(safeBase, safeFileName));
-
-        // Ensure the resolved path stays within the working directory
-        if (!fullPath.StartsWith(safeBase + Path.DirectorySeparatorChar, StringComparison.Ordinal) && fullPath != safeBase)
-            throw new UnauthorizedAccessException("Path escapes the working directory.");
-
+        var fullPath = _paths.ResolveExportPath(path, "conversation.md");
+        Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
         await File.WriteAllTextAsync(fullPath, contentToWrite);
         return fullPath;
     }

--- a/CoffeeTalk.Core/Services/ConfigurationService.cs
+++ b/CoffeeTalk.Core/Services/ConfigurationService.cs
@@ -8,12 +8,22 @@ public class ConfigurationService
 {
     private const string SettingsFile = "appsettings.json";
     private static readonly JsonSerializerOptions _jsonOptions = new() { WriteIndented = true };
+    private readonly IApplicationDataPathResolver _paths;
+
+    public ConfigurationService(IApplicationDataPathResolver? paths = null)
+    {
+        _paths = paths ?? new ApplicationDataPathResolver();
+    }
 
     public AppSettings LoadConfiguration()
     {
+        var settingsPath = File.Exists(_paths.ConfigurationFilePath)
+            ? _paths.ConfigurationFilePath
+            : FindLegacyConfigurationPath();
+
         var configuration = new ConfigurationBuilder()
-            .SetBasePath(AppContext.BaseDirectory)
-            .AddJsonFile(SettingsFile, optional: true, reloadOnChange: false)
+            .SetBasePath(Path.GetDirectoryName(settingsPath)!)
+            .AddJsonFile(Path.GetFileName(settingsPath), optional: true, reloadOnChange: false)
             .Build();
 
         var settings = new AppSettings();
@@ -31,7 +41,18 @@ public class ConfigurationService
         var persistedSettings = MapToPersistedAppSettings(settings);
         var json = JsonSerializer.Serialize(persistedSettings, _jsonOptions);
 
-        await File.WriteAllTextAsync(SettingsFile, json);
+        Directory.CreateDirectory(_paths.RootDirectory);
+        await File.WriteAllTextAsync(_paths.ConfigurationFilePath, json);
+    }
+
+    private static string FindLegacyConfigurationPath()
+    {
+        var basePath = Path.Combine(AppContext.BaseDirectory, SettingsFile);
+        if (File.Exists(basePath))
+            return basePath;
+
+        var currentPath = Path.GetFullPath(SettingsFile);
+        return currentPath;
     }
 
     // Helper method to map AppSettings to PersistedAppSettings, omitting sensitive fields
@@ -44,7 +65,7 @@ public class ConfigurationService
                 Type = settings.LlmProvider.Type,
                 Endpoint = settings.LlmProvider.Endpoint,
                 ModelId = settings.LlmProvider.ModelId,
-                DeploymentName = settings.LlmProvider.DeploymentName
+                DeploymentName = settings.LlmProvider.DeploymentName ?? string.Empty
                 // ApiKey is intentionally omitted
             },
             Personas = settings.Personas,
@@ -59,7 +80,8 @@ public class ConfigurationService
             Retry = settings.Retry,
             Orchestrator = settings.Orchestrator,
             Editor = settings.Editor,
-            DynamicPersonas = settings.DynamicPersonas
+            DynamicPersonas = settings.DynamicPersonas,
+            Tools = settings.Tools
         };
     }
 }

--- a/CoffeeTalk.Core/Services/MarkdownToolFunctions.cs
+++ b/CoffeeTalk.Core/Services/MarkdownToolFunctions.cs
@@ -80,7 +80,7 @@ public class MarkdownToolFunctions
     }
 
     [Description("Save the shared markdown document to disk and return the full file path")]
-    public Task<string> SaveToFileAsync([Description("Output path; default is conversation.md in the working directory")] string? path = null)
+    public Task<string> SaveToFileAsync([Description("Output path relative to the CoffeeTalk exports directory; defaults to conversation.md")] string? path = null)
     {
         return _doc.SaveToFileAsync(path ?? "conversation.md");
     }

--- a/CoffeeTalk.Gui/Components/Pages/Conversation.razor
+++ b/CoffeeTalk.Gui/Components/Pages/Conversation.razor
@@ -2,6 +2,7 @@
 @using MudBlazor
 @using Microsoft.JSInterop
 @using Markdig
+@using CoffeeTalk.Services
 @namespace CoffeeTalk.Gui.Components
 @implements IDisposable
 @inject BlazorUserInterface UI
@@ -9,6 +10,7 @@
 @inject ISnackbar Snackbar
 @inject IDialogService DialogService
 @inject IJSRuntime JSRuntime
+@inject IApplicationDataPathResolver DataPaths
 
 @if (UI.IsConversationRunning || !string.IsNullOrEmpty(UI.ConversationTopic))
 {
@@ -190,8 +192,10 @@
         try
         {
             var fileName = $"conversation_{DateTime.Now:yyyyMMdd_HHmmss}.md";
-            await File.WriteAllTextAsync(fileName, UI.DocumentMarkdown);
-            Snackbar.Add($"Saved to {fileName}", Severity.Success);
+            var path = DataPaths.ResolveExportPath(fileName, "conversation.md");
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            await File.WriteAllTextAsync(path, UI.DocumentMarkdown);
+            Snackbar.Add($"Saved to {path}", Severity.Success);
         }
         catch (IOException ex)
         {
@@ -273,11 +277,22 @@
                     break;
             }
 
-            var fileName = $"{UI.ConversationTopic ?? "conversation"}_{DateTime.Now:yyyyMMdd_HHmmss}.{extension}";
-            await File.WriteAllTextAsync(fileName, content);
-            Snackbar.Add($"Exported to {fileName}", Severity.Success);
+            var topic = MakeSafeFileNamePart(UI.ConversationTopic ?? "conversation");
+            var fileName = $"{topic}_{DateTime.Now:yyyyMMdd_HHmmss}.{extension}";
+            var path = DataPaths.ResolveExportPath(fileName, "conversation.md");
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            await File.WriteAllTextAsync(path, content);
+            Snackbar.Add($"Exported to {path}", Severity.Success);
         }
         catch (IOException ex)
+        {
+            Snackbar.Add($"Export failed: {ex.Message}", Severity.Error);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            Snackbar.Add($"Export failed: {ex.Message}", Severity.Error);
+        }
+        catch (ArgumentException ex)
         {
             Snackbar.Add($"Export failed: {ex.Message}", Severity.Error);
         }
@@ -373,6 +388,14 @@
     private static string EscapeHtml(string text) => System.Net.WebUtility.HtmlEncode(text);
 
     private static string EscapeJson(string text) => text.Replace("\\", "\\\\").Replace("\"", "\\\"").Replace("\n", "\\n").Replace("\r", "\\r").Replace("\t", "\\t");
+
+    private static string MakeSafeFileNamePart(string value)
+    {
+        var invalidCharacters = Path.GetInvalidFileNameChars();
+        var safe = new string(value.Select(character =>
+            invalidCharacters.Contains(character) || character is '/' or '\\' ? '_' : character).ToArray()).Trim();
+        return string.IsNullOrWhiteSpace(safe) ? "conversation" : safe;
+    }
 
     private int GetMessageCount()
     {

--- a/CoffeeTalk.Gui/Components/Pages/Home.razor
+++ b/CoffeeTalk.Gui/Components/Pages/Home.razor
@@ -13,6 +13,7 @@
 @inject NavigationManager Navigation
 @inject ILogger<Home> Logger
 @inject ConversationHistoryService History
+@inject IApplicationDataPathResolver DataPaths
 
 
 <MudContainer MaxWidth="MaxWidth.Medium" Class="mt-8">
@@ -144,7 +145,7 @@
     {
         try
         {
-            var sharedDoc = new CollaborativeMarkdownDocument();
+            var sharedDoc = new CollaborativeMarkdownDocument(DataPaths);
             var markdownTools = new MarkdownToolFunctions(sharedDoc);
             var tools = markdownTools.CreateTools();
             var settings = AppState.Settings;

--- a/CoffeeTalk.Gui/Program.cs
+++ b/CoffeeTalk.Gui/Program.cs
@@ -15,6 +15,7 @@ class Program
         var appBuilder = PhotinoBlazorAppBuilder.CreateDefault(args);
 
         appBuilder.Services.AddLogging();
+        appBuilder.Services.AddSingleton<IApplicationDataPathResolver, ApplicationDataPathResolver>();
         appBuilder.Services.AddSingleton<ConfigurationService>();
         appBuilder.Services.AddSingleton<AppState>();
         appBuilder.Services.AddSingleton<ConversationHistoryService>();

--- a/CoffeeTalk.Gui/Services/ConversationHistoryService.cs
+++ b/CoffeeTalk.Gui/Services/ConversationHistoryService.cs
@@ -1,18 +1,18 @@
 using System.Text.Json;
+using CoffeeTalk.Services;
 
 namespace CoffeeTalk.Gui.Services;
 
 public sealed class ConversationHistoryService
 {
-    private readonly string _historyPath = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-        "CoffeeTalk",
-        "conversation-history.json");
+    private readonly string _historyPath;
     private readonly object _sync = new();
     private readonly List<ConversationRecord> _records;
 
-    public ConversationHistoryService()
+    public ConversationHistoryService(IApplicationDataPathResolver? paths = null)
     {
+        var resolver = paths ?? new ApplicationDataPathResolver();
+        _historyPath = resolver.ResolveDataPath("conversation-history.json", "conversation-history.json");
         _records = Load();
     }
 

--- a/CoffeeTalk.Tests/ApplicationDataPathResolverTests.cs
+++ b/CoffeeTalk.Tests/ApplicationDataPathResolverTests.cs
@@ -1,0 +1,27 @@
+using CoffeeTalk.Services;
+
+namespace CoffeeTalk.Tests;
+
+public sealed class ApplicationDataPathResolverTests
+{
+    [Fact]
+    public void ResolveExportPath_UsesExportDirectory()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "coffeetalk-tests", Guid.NewGuid().ToString("N"));
+        var resolver = new ApplicationDataPathResolver(root);
+
+        var path = resolver.ResolveExportPath("nested/conversation.md", "conversation.md");
+
+        Assert.Equal(Path.Combine(root, "exports", "nested", "conversation.md"), path);
+    }
+
+    [Theory]
+    [InlineData("../outside.txt")]
+    [InlineData("/tmp/outside.txt")]
+    public void ResolveDataPath_RejectsEscapes(string path)
+    {
+        var resolver = new ApplicationDataPathResolver(Path.Combine(Path.GetTempPath(), "coffeetalk-tests", Guid.NewGuid().ToString("N")));
+
+        Assert.Throws<UnauthorizedAccessException>(() => resolver.ResolveDataPath(path, "data.json"));
+    }
+}

--- a/CoffeeTalk.Tests/ConfigurationServiceTests.cs
+++ b/CoffeeTalk.Tests/ConfigurationServiceTests.cs
@@ -1,0 +1,27 @@
+using CoffeeTalk.Models;
+using CoffeeTalk.Services;
+
+namespace CoffeeTalk.Tests;
+
+public sealed class ConfigurationServiceTests
+{
+    [Fact]
+    public async Task SaveAndLoad_UsesInjectedAbsolutePathAndPersistsTools()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "coffeetalk-tests", Guid.NewGuid().ToString("N"));
+        var resolver = new ApplicationDataPathResolver(root);
+        var service = new ConfigurationService(resolver);
+        var settings = new AppSettings
+        {
+            LlmProvider = new LlmProviderConfig { Type = "ollama", ModelId = "test-model" },
+            Tools = new ToolsConfig { EnableFallbackJsonTools = false, RequireToolsVerification = false }
+        };
+
+        await service.SaveSettingsAsync(settings);
+        var loaded = service.LoadConfiguration();
+
+        Assert.True(Path.IsPathFullyQualified(resolver.ConfigurationFilePath));
+        Assert.Equal(false, loaded.Tools?.EnableFallbackJsonTools);
+        Assert.Equal(false, loaded.Tools?.RequireToolsVerification);
+    }
+}

--- a/CoffeeTalk.Tests/ConversationComponentTests.cs
+++ b/CoffeeTalk.Tests/ConversationComponentTests.cs
@@ -17,6 +17,8 @@ public class ConversationComponentTests : TestContext
         Services.AddMudServices();
         Services.AddSingleton<ConfigurationService>();
         Services.AddSingleton<AppState>();
+        Services.AddSingleton<IApplicationDataPathResolver>(
+            new ApplicationDataPathResolver(Path.Combine(Path.GetTempPath(), "coffeetalk-tests", Guid.NewGuid().ToString("N"))));
         Services.AddSingleton<MudBlazor.ISnackbar, MudBlazor.SnackbarService>();
 
         var ui = new BlazorUserInterface();

--- a/CoffeeTalk/Program.cs
+++ b/CoffeeTalk/Program.cs
@@ -13,7 +13,8 @@ class Program
     {
         try
         {
-            var configService = new ConfigurationService();
+            var dataPaths = new ApplicationDataPathResolver();
+            var configService = new ConfigurationService(dataPaths);
             var settings = configService.LoadConfiguration();
 
             // Validate and interactively configure if needed using the CLI Helper
@@ -38,7 +39,7 @@ class Program
                     }));
 
             // Create shared collaborative document
-            var sharedDoc = new CollaborativeMarkdownDocument();
+            var sharedDoc = new CollaborativeMarkdownDocument(dataPaths);
 
             // Create markdown tool functions
             var markdownTools = new MarkdownToolFunctions(sharedDoc);
@@ -219,7 +220,7 @@ class Program
             {
                 var prompt = AgentDataExtractor.BuildSystemPrompt(settings.StructuredData);
                 var agent = AgentBuilder.CreateAgent(settings.LlmProvider, "DataExtractor", prompt);
-                dataExtractor = new AgentDataExtractor(agent, settings.StructuredData, sharedDoc);
+                dataExtractor = new AgentDataExtractor(agent, settings.StructuredData, sharedDoc, dataPaths);
             }
 
             // Instantiate UI


### PR DESCRIPTION
Implements the foundation for issues #27 and #89 with a shared injectable CoffeeTalk data/export path resolver. Configuration now loads and saves through an absolute per-user path with legacy fallback, ToolsConfig is persisted, and structured extraction, markdown saves, GUI exports, history, and autosave use the resolver with traversal protection.

Tests: dotnet build CoffeeTalk.sln; dotnet test CoffeeTalk.Tests/CoffeeTalk.Tests.csproj