### PR TITLE
Secure conversation rendering and exports

### DIFF
--- a/CoffeeTalk.Gui/Components/Pages/Conversation.razor
+++ b/CoffeeTalk.Gui/Components/Pages/Conversation.razor
@@ -1,7 +1,6 @@
 @using CoffeeTalk.Gui.Services
 @using MudBlazor
 @using Microsoft.JSInterop
-@using Markdig
 @using CoffeeTalk.Services
 @namespace CoffeeTalk.Gui.Components
 @implements IDisposable
@@ -147,11 +146,6 @@
     private int _documentTab;
     private string? _exportFormat;
 
-    private static readonly MarkdownPipeline _markdownPipeline = new MarkdownPipelineBuilder()
-        .UsePipeTables()
-        .UseGridTables()
-        .Build();
-
     protected override void OnInitialized()
     {
         UI.OnChange += OnUiChanged;
@@ -261,17 +255,29 @@
             switch (format.ToLower())
             {
                 case "html":
-                    content = GenerateHtmlExport();
+                    content = ConversationExportService.GenerateHtml(
+                        UI.ConversationTopic,
+                        UI.ConversationStartedAt,
+                        UI.ConversationParticipants,
+                        UI.Messages);
                     extension = "html";
                     mimeType = "text/html";
                     break;
                 case "json":
-                    content = GenerateJsonExport();
+                    content = ConversationExportService.GenerateJson(
+                        UI.ConversationTopic,
+                        UI.ConversationStartedAt,
+                        UI.ConversationParticipants,
+                        UI.Messages);
                     extension = "json";
                     mimeType = "application/json";
                     break;
                 default:
-                    content = UI.DocumentMarkdown;
+                    content = ConversationExportService.GenerateMarkdown(
+                        UI.ConversationTopic,
+                        UI.ConversationStartedAt,
+                        UI.ConversationParticipants,
+                        UI.Messages);
                     extension = "md";
                     mimeType = "text/markdown";
                     break;
@@ -297,97 +303,6 @@
             Snackbar.Add($"Export failed: {ex.Message}", Severity.Error);
         }
     }
-
-    private string GenerateHtmlExport()
-    {
-        var html = @"<!DOCTYPE html>
-<html>
-<head>
-    <meta charset=""utf-8"">
-    <title>";
-        html += UI.ConversationTopic ?? "Conversation";
-        html += @"</title>
-    <style>
-        body { font-family: Arial, sans-serif; max-width: 800px; margin: 0 auto; padding: 20px; }
-        .message { margin: 10px 0; padding: 10px; border-left: 3px solid #ccc; }
-        .sender { font-weight: bold; color: #666; }
-        .timestamp { color: #999; font-size: 0.8em; }
-        .system { background: #f5f5f5; padding: 5px; border-radius: 3px; }
-        .error { background: #ffebee; padding: 5px; border-radius: 3px; }
-    </style>
-</head>
-<body>
-    <h1>";
-        html += UI.ConversationTopic ?? "Conversation";
-        html += @"</h1>
-    <p>Started: " + (UI.ConversationStartedAt?.ToString("yyyy-MM-dd HH:mm") ?? "Unknown") + @"</p>
-    <hr/>
-";
-
-        foreach (var msg in UI.Messages)
-        {
-            if (msg.IsDivider)
-            {
-                html += "    <hr/>\n";
-            }
-            else if (msg.IsSystem)
-            {
-                html += $"    <div class=\"system\">{EscapeHtml(msg.Content)}</div>\n";
-            }
-            else if (msg.IsError)
-            {
-                html += $"    <div class=\"error\">{EscapeHtml(msg.Content)}</div>\n";
-            }
-            else
-            {
-                html += $"    <div class=\"message\">\n";
-                html += $"        <span class=\"sender\">{EscapeHtml(msg.Sender)}</span> ";
-                html += $"<span class=\"timestamp\">({msg.Timestamp:HH:mm})</span>\n";
-                html += $"        <div>{RenderMarkdown(msg.Content)}</div>\n";
-                html += "    </div>\n";
-            }
-        }
-
-        html += "</body>\n</html>";
-        return html;
-    }
-
-    private string GenerateJsonExport()
-    {
-        var json = "{\n";
-        var startedAt = UI.ConversationStartedAt?.ToString("o") ?? "";
-        var topic = EscapeJson(UI.ConversationTopic ?? "");
-        json += $"  \"topic\": \"{topic}\",\n";
-        json += $"  \"startedAt\": \"{startedAt}\",\n";
-        
-        var participants = "[" + string.Join(", ", UI.ConversationParticipants.Select(p => $"\"{EscapeJson(p)}\"")) + "]";
-        json += $"  \"participants\": {participants},\n";
-        json += "  \"messages\": [\n";
-
-        for (int i = 0; i < UI.Messages.Count; i++)
-        {
-            var msg = UI.Messages[i];
-            json += "    {\n";
-            json += $"      \"sender\": \"{EscapeJson(msg.Sender)}\",\n";
-            json += $"      \"content\": \"{EscapeJson(msg.Content)}\",\n";
-            var ts = msg.Timestamp.ToString("o");
-            json += $"      \"timestamp\": \"{ts}\",\n";
-            json += $"      \"isSystem\": {msg.IsSystem.ToString().ToLower()},\n";
-            json += $"      \"isError\": {msg.IsError.ToString().ToLower()},\n";
-            json += $"      \"isDivider\": {msg.IsDivider.ToString().ToLower()}\n";
-            json += "    }";
-            json += i < UI.Messages.Count - 1 ? "," : "";
-            json += "\n";
-        }
-
-        json += "  ]\n";
-        json += "}";
-        return json;
-    }
-
-    private static string EscapeHtml(string text) => System.Net.WebUtility.HtmlEncode(text);
-
-    private static string EscapeJson(string text) => text.Replace("\\", "\\\\").Replace("\"", "\\\"").Replace("\n", "\\n").Replace("\r", "\\r").Replace("\t", "\\t");
 
     private static string MakeSafeFileNamePart(string value)
     {
@@ -416,6 +331,6 @@
     {
         if (string.IsNullOrWhiteSpace(markdown))
             return "";
-        return Markdig.Markdown.ToHtml(markdown.Trim(), _markdownPipeline);
+        return ConversationExportService.RenderMarkdown(markdown);
     }
 }

--- a/CoffeeTalk.Gui/Services/ConversationExportService.cs
+++ b/CoffeeTalk.Gui/Services/ConversationExportService.cs
@@ -1,0 +1,177 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Markdig;
+using Markdig.Syntax;
+using Markdig.Syntax.Inlines;
+
+namespace CoffeeTalk.Gui.Services;
+
+public static class ConversationExportService
+{
+    private static readonly MarkdownPipeline MarkdownPipeline = new MarkdownPipelineBuilder()
+        .DisableHtml()
+        .UsePipeTables()
+        .UseGridTables()
+        .Build();
+
+    public static string RenderMarkdown(string? markdown)
+    {
+        if (string.IsNullOrWhiteSpace(markdown))
+            return string.Empty;
+
+        var document = Markdig.Markdown.Parse(markdown.Trim(), MarkdownPipeline);
+        foreach (var link in document.Descendants<LinkInline>())
+        {
+            if (!IsSafeLink(link.Url))
+                link.Url = null;
+        }
+
+        return Markdig.Markdown.ToHtml(document, MarkdownPipeline);
+    }
+
+    public static string GenerateMarkdown(
+        string? topic,
+        DateTime? startedAt,
+        IReadOnlyCollection<string> participants,
+        IReadOnlyList<ChatMessage> messages)
+    {
+        var builder = new StringBuilder();
+        builder.Append("# ").AppendLine(EscapeMarkdown(topic ?? "Conversation"));
+        builder.Append("Started: ").AppendLine(startedAt?.ToString("yyyy-MM-dd HH:mm") ?? "Unknown");
+        builder.Append("Participants: ").AppendLine(string.Join(", ", participants.Select(EscapeMarkdown)));
+        builder.AppendLine();
+
+        foreach (var message in messages)
+        {
+            if (message.IsDivider)
+            {
+                builder.AppendLine("---");
+                if (!string.IsNullOrWhiteSpace(message.Content))
+                    builder.AppendLine(message.Content);
+                builder.AppendLine();
+                continue;
+            }
+
+            builder.Append("**").Append(EscapeMarkdown(message.Sender)).Append("** ");
+            builder.Append("_(").Append(message.Timestamp.ToString("HH:mm")).AppendLine(")_");
+            builder.AppendLine();
+            builder.AppendLine(message.Content);
+            builder.AppendLine();
+        }
+
+        return builder.ToString().TrimEnd() + Environment.NewLine;
+    }
+
+    public static string GenerateHtml(
+        string? topic,
+        DateTime? startedAt,
+        IReadOnlyCollection<string> participants,
+        IReadOnlyList<ChatMessage> messages)
+    {
+        var title = EscapeHtml(topic ?? "Conversation");
+        var builder = new StringBuilder();
+        builder.AppendLine("<!DOCTYPE html>")
+            .AppendLine("<html>")
+            .AppendLine("<head>")
+            .AppendLine("    <meta charset=\"utf-8\">")
+            .Append("    <title>").Append(title).AppendLine("</title>")
+            .AppendLine("    <style>")
+            .AppendLine("        body { font-family: Arial, sans-serif; max-width: 800px; margin: 0 auto; padding: 20px; }")
+            .AppendLine("        .message { margin: 10px 0; padding: 10px; border-left: 3px solid #ccc; }")
+            .AppendLine("        .sender { font-weight: bold; color: #666; }")
+            .AppendLine("        .timestamp { color: #999; font-size: 0.8em; }")
+            .AppendLine("        .system { background: #f5f5f5; padding: 5px; border-radius: 3px; }")
+            .AppendLine("        .error { background: #ffebee; padding: 5px; border-radius: 3px; }")
+            .AppendLine("    </style>")
+            .AppendLine("</head>")
+            .AppendLine("<body>")
+            .Append("    <h1>").Append(title).AppendLine("</h1>")
+            .Append("    <p>Started: ")
+            .Append(EscapeHtml(startedAt?.ToString("yyyy-MM-dd HH:mm") ?? "Unknown"))
+            .AppendLine("</p>")
+            .Append("    <p>Participants: ")
+            .Append(EscapeHtml(string.Join(", ", participants)))
+            .AppendLine("</p>")
+            .AppendLine("    <hr/>");
+
+        foreach (var message in messages)
+        {
+            if (message.IsDivider)
+            {
+                builder.AppendLine("    <hr/>");
+            }
+            else if (message.IsSystem)
+            {
+                builder.Append("    <div class=\"system\">")
+                    .Append(EscapeHtml(message.Content))
+                    .AppendLine("</div>");
+            }
+            else if (message.IsError)
+            {
+                builder.Append("    <div class=\"error\">")
+                    .Append(EscapeHtml(message.Content))
+                    .AppendLine("</div>");
+            }
+            else
+            {
+                builder.AppendLine("    <div class=\"message\">")
+                    .Append("        <span class=\"sender\">")
+                    .Append(EscapeHtml(message.Sender))
+                    .Append("</span> <span class=\"timestamp\">(")
+                    .Append(message.Timestamp.ToString("HH:mm"))
+                    .AppendLine(")</span>")
+                    .Append("        <div>")
+                    .Append(RenderMarkdown(message.Content))
+                    .AppendLine("</div>")
+                    .AppendLine("    </div>");
+            }
+        }
+
+        return builder.AppendLine("</body>").AppendLine("</html>").ToString();
+    }
+
+    public static string GenerateJson(
+        string? topic,
+        DateTime? startedAt,
+        IReadOnlyCollection<string> participants,
+        IReadOnlyList<ChatMessage> messages)
+    {
+        return JsonSerializer.Serialize(new
+        {
+            topic = topic ?? string.Empty,
+            startedAt,
+            participants,
+            messages
+        }, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = true
+        });
+    }
+
+    private static string EscapeHtml(string text) => WebUtility.HtmlEncode(text);
+
+    private static bool IsSafeLink(string? url)
+    {
+        if (string.IsNullOrWhiteSpace(url) || url.StartsWith("//", StringComparison.Ordinal))
+            return false;
+
+        if (!Uri.TryCreate(url, UriKind.RelativeOrAbsolute, out var uri) || !uri.IsAbsoluteUri)
+            return true;
+
+        return uri.Scheme is "http" or "https" or "mailto";
+    }
+
+    private static string EscapeMarkdown(string text) =>
+        text.Replace("\\", "\\\\")
+            .Replace("`", "\\`")
+            .Replace("*", "\\*")
+            .Replace("_", "\\_")
+            .Replace("[", "\\[")
+            .Replace("]", "\\]")
+            .Replace("<", "\\<")
+            .Replace(">", "\\>")
+            .Replace("#", "\\#")
+            .Replace("|", "\\|");
+}

--- a/CoffeeTalk.Tests/ApplicationDataPathResolverTests.cs
+++ b/CoffeeTalk.Tests/ApplicationDataPathResolverTests.cs
@@ -16,6 +16,16 @@ public sealed class ApplicationDataPathResolverTests
     }
 
     [Theory]
+    [InlineData("../outside.html")]
+    [InlineData("/tmp/outside.json")]
+    public void ResolveExportPath_RejectsEscapes(string path)
+    {
+        var resolver = new ApplicationDataPathResolver(Path.Combine(Path.GetTempPath(), "coffeetalk-tests", Guid.NewGuid().ToString("N")));
+
+        Assert.Throws<UnauthorizedAccessException>(() => resolver.ResolveExportPath(path, "conversation.md"));
+    }
+
+    [Theory]
     [InlineData("../outside.txt")]
     [InlineData("/tmp/outside.txt")]
     public void ResolveDataPath_RejectsEscapes(string path)

--- a/CoffeeTalk.Tests/ConversationExportServiceTests.cs
+++ b/CoffeeTalk.Tests/ConversationExportServiceTests.cs
@@ -1,0 +1,96 @@
+using System.Text.Json;
+using CoffeeTalk.Gui.Services;
+
+namespace CoffeeTalk.Tests;
+
+public sealed class ConversationExportServiceTests
+{
+    [Fact]
+    public void RenderMarkdown_DisablesRawHtmlAndEventHandlers()
+    {
+        var rendered = ConversationExportService.RenderMarkdown(
+            "<script>alert('x')</script><div onclick=\"alert('x')\">message</div>");
+
+        Assert.DoesNotContain("<script", rendered, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(" onclick=\"", rendered, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("&lt;script&gt;", rendered);
+    }
+
+    [Fact]
+    public void RenderMarkdown_BlocksUnsafeLinkSchemes()
+    {
+        var rendered = ConversationExportService.RenderMarkdown(
+            "[unsafe](javascript:alert(1)) [safe](https://example.com)");
+
+        Assert.DoesNotContain("javascript:", rendered, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("href=\"https://example.com\"", rendered);
+    }
+
+    [Fact]
+    public void GenerateHtml_EscapesTopicParticipantsAndMessageMetadata()
+    {
+        var message = new ChatMessage
+        {
+            Sender = "<img src=x onerror=alert(1)>",
+            Content = "safe",
+            Timestamp = new DateTime(2026, 1, 2, 3, 4, 0)
+        };
+
+        var html = ConversationExportService.GenerateHtml(
+            "<script>alert(1)</script>",
+            new DateTime(2026, 1, 2, 3, 4, 0),
+            new[] { "<b>participant</b>" },
+            new[] { message });
+
+        Assert.Contains("&lt;script&gt;alert(1)&lt;/script&gt;", html);
+        Assert.Contains("&lt;b&gt;participant&lt;/b&gt;", html);
+        Assert.Contains("&lt;img src=x onerror=alert(1)&gt;", html);
+        Assert.DoesNotContain("<script>alert(1)</script>", html);
+        Assert.DoesNotContain("<img src=x onerror=alert(1)>", html);
+    }
+
+    [Fact]
+    public void GenerateMarkdown_IncludesMetadataAndEveryMessage()
+    {
+        var messages = new[]
+        {
+            new ChatMessage { Sender = "Agent A", Content = "First response" },
+            new ChatMessage { Sender = "System", Content = "A divider", IsDivider = true },
+            new ChatMessage { Sender = "Agent B", Content = "Second response" }
+        };
+
+        var markdown = ConversationExportService.GenerateMarkdown(
+            "Project topic",
+            new DateTime(2026, 1, 2, 3, 4, 0),
+            new[] { "Agent A", "Agent B" },
+            messages);
+
+        Assert.Contains("# Project topic", markdown);
+        Assert.Contains("Started: 2026-01-02 03:04", markdown);
+        Assert.Contains("Participants: Agent A, Agent B", markdown);
+        Assert.Contains("First response", markdown);
+        Assert.Contains("A divider", markdown);
+        Assert.Contains("Second response", markdown);
+    }
+
+    [Fact]
+    public void GenerateJson_ProducesValidJsonWithAllMessages()
+    {
+        var messages = new[]
+        {
+            new ChatMessage { Sender = "Agent", Content = "quoted \"value\"\nnext" }
+        };
+
+        var json = ConversationExportService.GenerateJson(
+            "Topic",
+            DateTime.UtcNow,
+            new[] { "Agent" },
+            messages);
+
+        using var document = JsonDocument.Parse(json);
+        Assert.Equal("Topic", document.RootElement.GetProperty("topic").GetString());
+        Assert.Single(document.RootElement.GetProperty("messages").EnumerateArray());
+        Assert.Equal("quoted \"value\"\nnext",
+            document.RootElement.GetProperty("messages")[0].GetProperty("content").GetString());
+    }
+}


### PR DESCRIPTION
## Summary
- disable raw HTML and unsafe link schemes in chat and HTML rendering
- generate complete Markdown, safely escaped HTML, and System.Text.Json exports
- keep export writes on the application data path resolver
- add focused security, transcript, JSON, and path-safety tests

## Scope
- Does not modify Home.razor or BlazorUserInterface lifecycle behavior.

## Tests
- dotnet test CoffeeTalk.Tests/CoffeeTalk.Tests.csproj (27 passed)