### PR TITLE
Build shared conversation pipeline

### DIFF
--- a/CoffeeTalk.Core/Services/AgentFactChecker.cs
+++ b/CoffeeTalk.Core/Services/AgentFactChecker.cs
@@ -12,7 +12,7 @@ public class AgentFactChecker
     private readonly IOperationalEventSink _eventSink;
 
     // Delegate for reporting alerts so we don't depend on UI directly
-    public event Action<string>? OnFactCheckAlert;
+    public event Func<string, Task>? OnFactCheckAlert;
 
     public AgentFactChecker(AIAgent agent, RateLimiter? rateLimiter, IRetryService retryService, IOperationalEventSink? eventSink = null)
     {
@@ -64,7 +64,10 @@ Output Format:
 
             if (!result.StartsWith("PASS", StringComparison.OrdinalIgnoreCase))
             {
-                OnFactCheckAlert?.Invoke(result);
+                if (OnFactCheckAlert != null)
+                {
+                    await OnFactCheckAlert.Invoke(result);
+                }
             }
         }
         catch (OperationCanceledException)

--- a/CoffeeTalk.Core/Services/ConversationPipelineBuilder.cs
+++ b/CoffeeTalk.Core/Services/ConversationPipelineBuilder.cs
@@ -48,7 +48,16 @@ public sealed class ConversationPipeline
     public AppSettings Settings { get; }
 
     public AgentConversationOrchestrator CreateConversation(IUserInterface ui)
-        => new(ui, Personas, SharedDocument, Settings, Orchestrator, Editor, DataExtractor, FactChecker);
+    {
+        ArgumentNullException.ThrowIfNull(ui);
+        if (FactChecker != null)
+        {
+            FactChecker.OnFactCheckAlert += alert =>
+                ui.ShowMessageAsync($"[bold red]Fact Checker Alert:[/] {alert}");
+        }
+
+        return new(ui, Personas, SharedDocument, Settings, Orchestrator, Editor, DataExtractor, FactChecker);
+    }
 }
 
 public sealed class ConversationPipelineBuilder
@@ -83,6 +92,10 @@ public sealed class ConversationPipelineBuilder
         var toolsConfig = settings.Tools ?? new ToolsConfig();
         var markdownTools = new MarkdownToolFunctions(sharedDocument, toolsConfig);
         var tools = markdownTools.CreateTools();
+        if (toolsConfig.RequireToolsVerification && !markdownTools.VerifyTools(tools))
+        {
+            throw new InvalidOperationException("Markdown tools failed verification.");
+        }
         var retryService = new RetryService(settings.Retry, _eventSink);
         var rateLimiter = new RateLimiter(settings.RateLimit);
         var personaConfigs = (selectedPersonas ?? settings.Personas).ToList();

--- a/CoffeeTalk.Core/Services/ConversationPipelineBuilder.cs
+++ b/CoffeeTalk.Core/Services/ConversationPipelineBuilder.cs
@@ -1,0 +1,275 @@
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using CoffeeTalk.Core.Interfaces;
+using CoffeeTalk.Models;
+
+namespace CoffeeTalk.Services;
+
+public interface IConversationAgentFactory
+{
+    AIAgent Create(LlmProviderConfig config, string name, string instructions, AIFunction[]? tools = null);
+}
+
+public sealed class ConversationAgentFactory : IConversationAgentFactory
+{
+    public AIAgent Create(LlmProviderConfig config, string name, string instructions, AIFunction[]? tools = null)
+        => AgentBuilder.CreateAgent(config, name, instructions, tools);
+}
+
+public sealed class ConversationPipeline
+{
+    internal ConversationPipeline(
+        CollaborativeMarkdownDocument sharedDocument,
+        ToolsConfig toolsConfig,
+        List<AgentPersona> personas,
+        AgentOrchestrator? orchestrator,
+        AgentEditor? editor,
+        AgentDataExtractor? dataExtractor,
+        AgentFactChecker? factChecker,
+        AppSettings settings)
+    {
+        SharedDocument = sharedDocument;
+        ToolsConfig = toolsConfig;
+        Personas = personas;
+        Orchestrator = orchestrator;
+        Editor = editor;
+        DataExtractor = dataExtractor;
+        FactChecker = factChecker;
+        Settings = settings;
+    }
+
+    public CollaborativeMarkdownDocument SharedDocument { get; }
+    public ToolsConfig ToolsConfig { get; }
+    public List<AgentPersona> Personas { get; }
+    public AgentOrchestrator? Orchestrator { get; }
+    public AgentEditor? Editor { get; }
+    public AgentDataExtractor? DataExtractor { get; }
+    public AgentFactChecker? FactChecker { get; }
+    public AppSettings Settings { get; }
+
+    public AgentConversationOrchestrator CreateConversation(IUserInterface ui)
+        => new(ui, Personas, SharedDocument, Settings, Orchestrator, Editor, DataExtractor, FactChecker);
+}
+
+public sealed class ConversationPipelineBuilder
+{
+    private const string DevilsAdvocateName = "DevilsAdvocate";
+    private readonly IApplicationDataPathResolver _dataPaths;
+    private readonly IOperationalEventSink _eventSink;
+    private readonly IConversationAgentFactory _agentFactory;
+
+    public ConversationPipelineBuilder(
+        IApplicationDataPathResolver dataPaths,
+        IOperationalEventSink? eventSink = null,
+        IConversationAgentFactory? agentFactory = null)
+    {
+        _dataPaths = dataPaths ?? throw new ArgumentNullException(nameof(dataPaths));
+        _eventSink = eventSink ?? NullOperationalEventSink.Instance;
+        _agentFactory = agentFactory ?? new ConversationAgentFactory();
+    }
+
+    public async Task<ConversationPipeline> BuildAsync(
+        AppSettings settings,
+        string topic,
+        IEnumerable<PersonaConfig>? selectedPersonas = null,
+        CancellationToken cancellationToken = default,
+        Action<string>? notify = null)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        if (string.IsNullOrWhiteSpace(topic))
+            throw new ArgumentException("A conversation topic is required.", nameof(topic));
+
+        var sharedDocument = new CollaborativeMarkdownDocument(_dataPaths);
+        var toolsConfig = settings.Tools ?? new ToolsConfig();
+        var markdownTools = new MarkdownToolFunctions(sharedDocument, toolsConfig);
+        var tools = markdownTools.CreateTools();
+        var retryService = new RetryService(settings.Retry, _eventSink);
+        var rateLimiter = new RateLimiter(settings.RateLimit);
+        var personaConfigs = (selectedPersonas ?? settings.Personas).ToList();
+
+        if (settings.DynamicPersonas?.Enabled == true)
+        {
+            personaConfigs = await GeneratePersonasAsync(
+                settings,
+                topic,
+                personaConfigs,
+                retryService,
+                cancellationToken,
+                notify);
+        }
+
+        var personas = CreatePersonas(settings, personaConfigs, sharedDocument, rateLimiter, retryService, tools);
+
+        if (settings.DevilsAdvocate &&
+            !personas.Any(persona => persona.Name.Equals(DevilsAdvocateName, StringComparison.OrdinalIgnoreCase)))
+        {
+            var config = new PersonaConfig
+            {
+                Name = DevilsAdvocateName,
+                SystemPrompt = "You are the Devil's Advocate. Your sole purpose is to challenge assumptions, find flaws in logic, and force the team to strengthen their arguments. Be constructive but relentless. Do not agree just to be polite. If everyone agrees, find a reason why they might be wrong."
+            };
+            personas.Add(CreatePersona(settings, config, sharedDocument, rateLimiter, retryService, personas.Count + 1, tools));
+            notify?.Invoke("Devil's Advocate injected.");
+        }
+
+        AgentOrchestrator? orchestrator = null;
+        if (settings.Orchestrator?.Enabled == true)
+        {
+            var config = settings.Orchestrator;
+            var agent = _agentFactory.Create(
+                settings.LlmProvider,
+                "Orchestrator",
+                AgentOrchestrator.BuildSystemPrompt(config, personas));
+            orchestrator = new AgentOrchestrator(agent, config, sharedDocument, personas, retryService, _eventSink);
+        }
+
+        AgentEditor? editor = null;
+        if (settings.Editor?.Enabled == true)
+        {
+            var config = settings.Editor;
+            var agent = _agentFactory.Create(
+                settings.LlmProvider,
+                "Editor",
+                AgentEditor.BuildSystemPrompt(config),
+                tools);
+            editor = new AgentEditor(agent, config, sharedDocument, rateLimiter, retryService);
+        }
+
+        AgentFactChecker? factChecker = null;
+        if (settings.FactChecking)
+        {
+            var agent = _agentFactory.Create(
+                settings.LlmProvider,
+                "FactChecker",
+                AgentFactChecker.BuildSystemPrompt());
+            factChecker = new AgentFactChecker(agent, rateLimiter, retryService, _eventSink);
+        }
+
+        AgentDataExtractor? dataExtractor = null;
+        if (settings.StructuredData?.Enabled == true)
+        {
+            var config = settings.StructuredData;
+            var agent = _agentFactory.Create(
+                settings.LlmProvider,
+                "DataExtractor",
+                AgentDataExtractor.BuildSystemPrompt(config));
+            dataExtractor = new AgentDataExtractor(agent, config, sharedDocument, retryService, _eventSink, _dataPaths);
+        }
+
+        return new ConversationPipeline(
+            sharedDocument,
+            toolsConfig,
+            personas,
+            orchestrator,
+            editor,
+            dataExtractor,
+            factChecker,
+            settings);
+    }
+
+    private async Task<List<PersonaConfig>> GeneratePersonasAsync(
+        AppSettings settings,
+        string topic,
+        List<PersonaConfig> configured,
+        IRetryService retryService,
+        CancellationToken cancellationToken,
+        Action<string>? notify)
+    {
+        var dynamicConfig = settings.DynamicPersonas!;
+        var generatorAgent = _agentFactory.Create(
+            settings.LlmProvider,
+            "PersonaGenerator",
+            AgentPersonaGenerator.BuildSystemPrompt());
+        var generator = new AgentPersonaGenerator(generatorAgent, retryService);
+        var requested = Math.Clamp(dynamicConfig.Count, 2, 10);
+        var replace = dynamicConfig.Mode?.Equals("replace", StringComparison.OrdinalIgnoreCase) == true;
+        var reserved = replace ? Array.Empty<string>() : configured.Select(persona => persona.Name);
+
+        try
+        {
+            var generated = await generator.GenerateAsync(topic, requested, reserved, cancellationToken);
+            var result = replace
+                ? generated
+                : MergePersonas(configured, generated);
+
+            if (result.Count < 2)
+            {
+                var topUp = await generator.GenerateAsync(
+                    topic,
+                    2 - result.Count,
+                    result.Select(persona => persona.Name),
+                    cancellationToken);
+                result.AddRange(topUp);
+            }
+
+            notify?.Invoke($"Dynamic personas enabled ({dynamicConfig.Mode}); using {result.Count} persona(s).");
+            return result.Take(10).ToList();
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is not OutOfMemoryException && ex is not StackOverflowException)
+        {
+            notify?.Invoke($"Dynamic persona generation failed: {ex.Message}. Using configured personas.");
+            return configured;
+        }
+    }
+
+    private static List<PersonaConfig> MergePersonas(
+        IEnumerable<PersonaConfig> configured,
+        IEnumerable<PersonaConfig> generated)
+    {
+        var result = new List<PersonaConfig>();
+        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var persona in configured.Concat(generated))
+        {
+            if (names.Add(persona.Name))
+                result.Add(persona);
+        }
+        return result;
+    }
+
+    private List<AgentPersona> CreatePersonas(
+        AppSettings settings,
+        IEnumerable<PersonaConfig> configs,
+        CollaborativeMarkdownDocument sharedDocument,
+        RateLimiter rateLimiter,
+        IRetryService retryService,
+        AIFunction[] tools)
+    {
+        var personaConfigs = configs.ToList();
+        return personaConfigs
+            .Select((config, index) => CreatePersona(
+                settings,
+                config,
+                sharedDocument,
+                rateLimiter,
+                retryService,
+                index + 1,
+                tools,
+                personaConfigs.Count))
+            .ToList();
+    }
+
+    private AgentPersona CreatePersona(
+        AppSettings settings,
+        PersonaConfig config,
+        CollaborativeMarkdownDocument sharedDocument,
+        RateLimiter rateLimiter,
+        IRetryService retryService,
+        int agentCount,
+        AIFunction[] tools,
+        int? totalPersonaCount = null)
+    {
+        var agent = _agentFactory.Create(settings.LlmProvider, config.Name, config.SystemPrompt, tools);
+        return new AgentPersona(
+            agent,
+            config,
+            sharedDocument,
+            rateLimiter,
+            settings.MaxConversationTurns,
+            totalPersonaCount ?? agentCount,
+            retryService);
+    }
+}

--- a/CoffeeTalk.Core/Services/MarkdownToolFunctions.cs
+++ b/CoffeeTalk.Core/Services/MarkdownToolFunctions.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.AI;
 using System.ComponentModel;
+using System.Text.Json;
 using CoffeeTalk.Models;
 
 namespace CoffeeTalk.Services;
@@ -23,7 +24,7 @@ public class MarkdownToolFunctions
     /// </summary>
     public AIFunction[] CreateTools()
     {
-        return new[]
+        var tools = new List<AIFunction>
         {
             AIFunctionFactory.Create(SetTitle),
             AIFunctionFactory.Create(AddHeading),
@@ -33,6 +34,18 @@ public class MarkdownToolFunctions
             AIFunctionFactory.Create(ListHeadings),
             AIFunctionFactory.Create(SaveToFileAsync)
         };
+
+        if (Configuration.EnableFallbackJsonTools)
+        {
+            tools.Add(AIFunctionFactory.Create(ExecuteJsonTool));
+        }
+
+        return tools.ToArray();
+    }
+
+    public bool VerifyTools(AIFunction[] tools)
+    {
+        return tools.Length >= 7;
     }
 
     [Description("Set the title (H1) of the shared markdown document")]
@@ -86,5 +99,29 @@ public class MarkdownToolFunctions
     public Task<string> SaveToFileAsync([Description("Output path relative to the CoffeeTalk exports directory; defaults to conversation.md")] string? path = null)
     {
         return _doc.SaveToFileAsync(path ?? "conversation.md");
+    }
+
+    [Description("Fallback tool dispatcher for providers that return tool calls as JSON")]
+    public string ExecuteJsonTool(
+        [Description("Tool name, such as SetTitle or AppendParagraph")] string toolName,
+        [Description("JSON object containing the tool arguments")] string argumentsJson)
+    {
+        using var arguments = JsonDocument.Parse(argumentsJson);
+        return toolName switch
+        {
+            "SetTitle" => SetTitle(arguments.RootElement.GetProperty("title").GetString() ?? string.Empty),
+            "AddHeading" => AddHeading(
+                arguments.RootElement.GetProperty("text").GetString() ?? string.Empty,
+                arguments.RootElement.TryGetProperty("level", out var level) ? level.GetInt32() : 2),
+            "AppendParagraph" => AppendParagraph(arguments.RootElement.GetProperty("text").GetString() ?? string.Empty),
+            "InsertAfterHeading" => InsertAfterHeading(
+                arguments.RootElement.GetProperty("headingText").GetString() ?? string.Empty,
+                arguments.RootElement.GetProperty("content").GetString() ?? string.Empty),
+            "ReplaceSection" => ReplaceSection(
+                arguments.RootElement.GetProperty("headingText").GetString() ?? string.Empty,
+                arguments.RootElement.GetProperty("content").GetString() ?? string.Empty),
+            "ListHeadings" => ListHeadings(),
+            _ => throw new ArgumentException($"Unsupported markdown tool: {toolName}", nameof(toolName))
+        };
     }
 }

--- a/CoffeeTalk.Core/Services/MarkdownToolFunctions.cs
+++ b/CoffeeTalk.Core/Services/MarkdownToolFunctions.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.AI;
 using System.ComponentModel;
+using CoffeeTalk.Models;
 
 namespace CoffeeTalk.Services;
 
@@ -9,10 +10,12 @@ namespace CoffeeTalk.Services;
 public class MarkdownToolFunctions
 {
     private readonly CollaborativeMarkdownDocument _doc;
+    public ToolsConfig Configuration { get; }
 
-    public MarkdownToolFunctions(CollaborativeMarkdownDocument doc)
+    public MarkdownToolFunctions(CollaborativeMarkdownDocument doc, ToolsConfig? configuration = null)
     {
         _doc = doc;
+        Configuration = configuration ?? new ToolsConfig();
     }
 
     /// <summary>

--- a/CoffeeTalk.Gui/Components/Pages/Home.razor
+++ b/CoffeeTalk.Gui/Components/Pages/Home.razor
@@ -15,6 +15,7 @@
 @inject ConversationHistoryService History
 @inject IApplicationDataPathResolver DataPaths
 @inject IOperationalEventSink OperationalEvents
+@inject ConversationPipelineBuilder PipelineBuilder
 
 
 <MudContainer MaxWidth="MaxWidth.Medium" Class="mt-8">
@@ -146,44 +147,10 @@
     {
         try
         {
-            var sharedDoc = new CollaborativeMarkdownDocument(DataPaths);
-            var markdownTools = new MarkdownToolFunctions(sharedDoc);
-            var tools = markdownTools.CreateTools();
             var settings = AppState.Settings;
-            var rateLimiter = new RateLimiter(settings.RateLimit);
-            var retryService = new RetryService(settings.Retry, OperationalEvents);
-
             var activePersonasConfig = SelectedPersonas.Cast<PersonaConfig>().ToList();
-
-            var activePersonas = new List<AgentPersona>();
-            foreach (var personaConfig in activePersonasConfig)
-            {
-                var agent = AgentBuilder.CreateAgent(
-                    settings.LlmProvider,
-                    personaConfig.Name,
-                    personaConfig.SystemPrompt,
-                    tools);
-
-                var agentPersona = new AgentPersona(
-                    agent,
-                    personaConfig,
-                    sharedDoc,
-                    rateLimiter,
-                    settings.MaxConversationTurns,
-                    activePersonasConfig.Count,
-                    retryService);
-
-                activePersonas.Add(agentPersona);
-            }
-
-            var conversationOrchestrator = new AgentConversationOrchestrator(
-                UI,
-                activePersonas,
-                sharedDoc,
-                settings
-            );
-
-            await conversationOrchestrator.StartConversationAsync(Topic, ct);
+            var pipeline = await PipelineBuilder.BuildAsync(settings, Topic, activePersonasConfig, ct);
+            await pipeline.CreateConversation(UI).StartConversationAsync(Topic, ct);
         }
         catch (OperationCanceledException)
         {

--- a/CoffeeTalk.Gui/Program.cs
+++ b/CoffeeTalk.Gui/Program.cs
@@ -21,6 +21,7 @@ class Program
         appBuilder.Services.AddSingleton<ConversationHistoryService>();
         appBuilder.Services.AddSingleton<BlazorOperationalEventSink>();
         appBuilder.Services.AddSingleton<IOperationalEventSink>(sp => sp.GetRequiredService<BlazorOperationalEventSink>());
+        appBuilder.Services.AddSingleton<ConversationPipelineBuilder>();
 
         // Register the UI as a singleton so it can be shared between the background task and the pages
         appBuilder.Services.AddSingleton<BlazorUserInterface>();

--- a/CoffeeTalk.Tests/ConversationPipelineBuilderTests.cs
+++ b/CoffeeTalk.Tests/ConversationPipelineBuilderTests.cs
@@ -29,6 +29,7 @@ public sealed class ConversationPipelineBuilderTests
         Assert.NotNull(pipeline.DataExtractor);
         Assert.Equal(settings.Tools!.RequireToolsVerification, pipeline.ToolsConfig.RequireToolsVerification);
         Assert.Contains(factory.Created, agent => agent.Name == "Editor" && agent.Tools?.Length > 0);
+        Assert.Contains(factory.Created, agent => agent.Name == "Analyst" && agent.Tools?.Length == 8);
     }
 
     [Fact]

--- a/CoffeeTalk.Tests/ConversationPipelineBuilderTests.cs
+++ b/CoffeeTalk.Tests/ConversationPipelineBuilderTests.cs
@@ -1,0 +1,97 @@
+using CoffeeTalk.Core.Interfaces;
+using CoffeeTalk.Models;
+using CoffeeTalk.Services;
+using Microsoft.Agents.AI;
+using Moq;
+using Xunit;
+
+namespace CoffeeTalk.Tests;
+
+public sealed class ConversationPipelineBuilderTests
+{
+    [Fact]
+    public async Task BuildAsync_AppliesEveryOptionalFeatureSetting()
+    {
+        var factory = new RecordingAgentFactory();
+        var settings = CreateSettings();
+        settings.DevilsAdvocate = true;
+        settings.FactChecking = true;
+        settings.Orchestrator!.Enabled = true;
+        settings.Editor!.Enabled = true;
+        settings.StructuredData!.Enabled = true;
+
+        var pipeline = await CreateBuilder(factory).BuildAsync(settings, "topic");
+
+        Assert.Equal(3, pipeline.Personas.Count);
+        Assert.NotNull(pipeline.Orchestrator);
+        Assert.NotNull(pipeline.Editor);
+        Assert.NotNull(pipeline.FactChecker);
+        Assert.NotNull(pipeline.DataExtractor);
+        Assert.Equal(settings.Tools!.RequireToolsVerification, pipeline.ToolsConfig.RequireToolsVerification);
+        Assert.Contains(factory.Created, agent => agent.Name == "Editor" && agent.Tools?.Length > 0);
+    }
+
+    [Fact]
+    public async Task BuildAsync_UsesSameEffectivePipelineForCliAndGuiInputs()
+    {
+        var settings = CreateSettings();
+        settings.DevilsAdvocate = true;
+        settings.Orchestrator!.Enabled = true;
+        settings.Tools = new ToolsConfig { EnableFallbackJsonTools = false, RequireToolsVerification = false };
+
+        var cli = await CreateBuilder(new RecordingAgentFactory()).BuildAsync(settings, "topic");
+        var gui = await CreateBuilder(new RecordingAgentFactory()).BuildAsync(
+            settings,
+            "topic",
+            settings.Personas.ToList());
+
+        Assert.Equal(
+            new[] { "Analyst", "Designer", "DevilsAdvocate" },
+            cli.Personas.Select(persona => persona.Name));
+        Assert.Equal(
+            cli.Personas.Select(persona => persona.Name),
+            gui.Personas.Select(persona => persona.Name));
+        Assert.Equal(cli.Orchestrator is not null, gui.Orchestrator is not null);
+        Assert.Equal(cli.ToolsConfig.RequireToolsVerification, gui.ToolsConfig.RequireToolsVerification);
+    }
+
+    private static ConversationPipelineBuilder CreateBuilder(RecordingAgentFactory factory)
+        => new(
+            new ApplicationDataPathResolver(Path.Combine(Path.GetTempPath(), "coffeetalk-tests", Guid.NewGuid().ToString("N"))),
+            agentFactory: factory);
+
+    private static AppSettings CreateSettings()
+        => new()
+        {
+            LlmProvider = new LlmProviderConfig
+            {
+                Type = "openai",
+                ModelId = "test",
+                ApiKey = "test"
+            },
+            Personas =
+            [
+                new PersonaConfig { Name = "Analyst", SystemPrompt = "You are Analyst." },
+                new PersonaConfig { Name = "Designer", SystemPrompt = "You are Designer." }
+            ],
+            Tools = new ToolsConfig(),
+            Orchestrator = new OrchestratorConfig(),
+            Editor = new EditorConfig(),
+            StructuredData = new StructuredDataConfig { SchemaDescription = "a record" }
+        };
+
+    private sealed class RecordingAgentFactory : IConversationAgentFactory
+    {
+        private readonly AIAgent _agent = new Mock<AIAgent>().Object;
+        public List<CreatedAgent> Created { get; } = new();
+
+        public AIAgent Create(LlmProviderConfig config, string name, string instructions, Microsoft.Extensions.AI.AIFunction[]? tools = null)
+        {
+            Created.Add(new CreatedAgent(name, tools));
+            return _agent;
+        }
+    }
+
+    private sealed record CreatedAgent(string Name, Microsoft.Extensions.AI.AIFunction[]? Tools);
+
+}

--- a/CoffeeTalk/Program.cs
+++ b/CoffeeTalk/Program.cs
@@ -16,233 +16,32 @@ class Program
             var dataPaths = new ApplicationDataPathResolver();
             var configService = new ConfigurationService(dataPaths);
             var settings = configService.LoadConfiguration();
-
-            // Validate and interactively configure if needed using the CLI Helper
             settings = await ConfigurationHelper.ValidateAndConfigureAsync(configService, settings);
 
             var eventSink = new CliOperationalEventSink();
-            var retryService = new RetryService(settings.Retry, eventSink);
-
-            // Display configuration summary
             AnsiConsole.MarkupLine($"[bold]Provider:[/] [cyan]{Markup.Escape(settings.LlmProvider.Type)}[/]");
             AnsiConsole.MarkupLine($"[bold]Model:[/] [cyan]{Markup.Escape(settings.LlmProvider.ModelId)}[/]");
             AnsiConsole.WriteLine();
 
-            // Get topic from user (needed for dynamic persona generation)
             var topic = AnsiConsole.Prompt(
                 new TextPrompt<string>("[bold yellow]What would you like the personas to discuss?[/]")
-                    .Validate(input =>
-                    {
-                        if (string.IsNullOrWhiteSpace(input))
-                            return ValidationResult.Error("[red]Please enter a non-empty topic.[/]");
-                        return ValidationResult.Success();
-                    }));
+                    .Validate(input => string.IsNullOrWhiteSpace(input)
+                        ? ValidationResult.Error("[red]Please enter a non-empty topic.[/]")
+                        : ValidationResult.Success()));
 
-            // Create shared collaborative document
-            var sharedDoc = new CollaborativeMarkdownDocument(dataPaths);
-
-            // Create markdown tool functions
-            var markdownTools = new MarkdownToolFunctions(sharedDoc);
-            var tools = markdownTools.CreateTools();
-
-            // Optionally generate personas dynamically
-            if (settings.DynamicPersonas?.Enabled == true)
-            {
-                await AnsiConsole.Status()
-                    .Spinner(Spinner.Known.Star)
-                    .StartAsync("Generating dynamic personas...", async ctx =>
-                    {
-                        try
-                        {
-                            var generatorPrompt = AgentPersonaGenerator.BuildSystemPrompt();
-                            var generatorAgent = AgentBuilder.CreateAgent(
-                                settings.LlmProvider,
-                                "PersonaGenerator",
-                                generatorPrompt);
-                            var generator = new AgentPersonaGenerator(generatorAgent, retryService);
-
-                            var requested = Math.Clamp(settings.DynamicPersonas.Count, 2, 10);
-                            var reserved = (settings.DynamicPersonas.Mode?.Equals("replace", StringComparison.OrdinalIgnoreCase) ?? false)
-                                ? Array.Empty<string>()
-                                : settings.Personas.Select(p => p.Name);
-
-                            var generated = await generator.GenerateAsync(topic, requested, reserved);
-
-                            List<PersonaConfig> finalList;
-                            if (settings.DynamicPersonas.Mode?.Equals("replace", StringComparison.OrdinalIgnoreCase) ?? false)
-                            {
-                                finalList = generated;
-                            }
-                            else
-                            {
-                                // augment: merge without duplicate names (case-insensitive), preferring existing personas
-                                var map = new Dictionary<string, PersonaConfig>(StringComparer.OrdinalIgnoreCase);
-                                foreach (var p in settings.Personas) map[p.Name] = p;
-                                foreach (var p in generated.Where(g => !map.ContainsKey(g.Name))) map[p.Name] = p;
-                                finalList = map.Values.ToList();
-                            }
-
-                            // Enforce total personas to 2..10
-                            if (finalList.Count < 2)
-                            {
-                                // top up with additional generated personas
-                                var topup = await generator.GenerateAsync(topic, 2 - finalList.Count, finalList.Select(p => p.Name));
-                                foreach (var p in topup) finalList.Add(p);
-                            }
-                            else if (finalList.Count > 10)
-                            {
-                                finalList = finalList.Take(10).ToList();
-                            }
-
-                            settings.Personas = finalList;
-
-                            AnsiConsole.MarkupLine($"[green]✓ Dynamic personas enabled ({settings.DynamicPersonas.Mode}). Using {settings.Personas.Count} persona(s): {string.Join(", ", settings.Personas.Select(p => Markup.Escape(p.Name)))}[/]\n");
-                        }
-                        catch (Exception ex)
-                        {
-                            AnsiConsole.MarkupLine($"[yellow]⚠️  Dynamic persona generation failed: {Markup.Escape(ex.Message)}. Proceeding with configured personas.[/]");
-                        }
-                    });
-            }
-            else
-            {
-                AnsiConsole.MarkupLine($"[bold]Personas:[/] {string.Join(", ", settings.Personas.Select(p => Markup.Escape(p.Name)))}\n");
-            }
-
-            // Create persona agents
-            var rateLimiter = new RateLimiter(settings.RateLimit);
-            var agentPersonas = new List<AgentPersona>();
-            
-            foreach (var personaConfig in settings.Personas)
-            {
-                var agent = AgentBuilder.CreateAgent(
-                    settings.LlmProvider,
-                    personaConfig.Name,
-                    personaConfig.SystemPrompt,
-                    tools);
-                
-                var agentPersona = new AgentPersona(
-                    agent,
-                    personaConfig,
-                    sharedDoc,
-                    rateLimiter,
-                    settings.MaxConversationTurns,
-                    settings.Personas.Count,
-                    retryService);
-                
-                agentPersonas.Add(agentPersona);
-            }
-
-            // Inject Devil's Advocate if enabled
-            if (settings.DevilsAdvocate)
-            {
-                var daConfig = new PersonaConfig
-                {
-                    Name = "DevilsAdvocate",
-                    SystemPrompt = "You are the Devil's Advocate. Your sole purpose is to challenge assumptions, find flaws in logic, and force the team to strengthen their arguments. Be constructive but relentless. Do not agree just to be polite. If everyone agrees, find a reason why they might be wrong."
-                };
-
-                // Avoid duplicate if already in config
-                if (!agentPersonas.Any(p => p.Name.Equals(daConfig.Name, StringComparison.OrdinalIgnoreCase)))
-                {
-                    var daAgent = AgentBuilder.CreateAgent(
-                        settings.LlmProvider,
-                        daConfig.Name,
-                        daConfig.SystemPrompt,
-                        tools);
-
-                    var daPersona = new AgentPersona(
-                        daAgent,
-                        daConfig,
-                        sharedDoc,
-                        rateLimiter,
-                        settings.MaxConversationTurns,
-                        agentPersonas.Count + 1,
-                        retryService); // +1 because we are adding it now
-
-                    agentPersonas.Add(daPersona);
-                    AnsiConsole.MarkupLine("[magenta]😈 Devil's Advocate injected![/]");
-                }
-            }
-
-            // Create orchestrator if enabled
-            AgentOrchestrator? orchestrator = null;
-            if (settings.Orchestrator?.Enabled ?? false)
-            {
-                var orchestratorConfig = settings.Orchestrator ?? new OrchestratorConfig();
-                var orchestratorPrompt = AgentOrchestrator.BuildSystemPrompt(orchestratorConfig, agentPersonas);
-                var orchestratorAgent = AgentBuilder.CreateAgent(
-                    settings.LlmProvider,
-                    "Orchestrator",
-                    orchestratorPrompt);
-                
-                orchestrator = new AgentOrchestrator(
-                    orchestratorAgent,
-                    orchestratorConfig,
-                    sharedDoc,
-                    agentPersonas,
-                    retryService,
-                    eventSink);
-            }
-
-            // Create editor if enabled
-            AgentEditor? editor = null;
-            if (settings.Editor?.Enabled ?? false)
-            {
-                var editorPrompt = AgentEditor.BuildSystemPrompt(settings.Editor);
-                var editorAgent = AgentBuilder.CreateAgent(
-                    settings.LlmProvider,
-                    "Editor",
-                    editorPrompt,
-                    tools);
-                
-                editor = new AgentEditor(
-                    editorAgent,
-                    settings.Editor,
-                    sharedDoc,
-                    rateLimiter,
-                    retryService);
-            }
-
-            // Create Fact Checker if enabled
-            AgentFactChecker? factChecker = null;
-            if (settings.FactChecking)
-            {
-                var factPrompt = AgentFactChecker.BuildSystemPrompt();
-                var factAgent = AgentBuilder.CreateAgent(settings.LlmProvider, "FactChecker", factPrompt);
-                factChecker = new AgentFactChecker(factAgent, rateLimiter, retryService, eventSink);
-                // Subscribe to alerts
-                factChecker.OnFactCheckAlert += (alert) =>
-                {
-                    AnsiConsole.MarkupLine($"\n[bold red]🕵️ Fact Checker Alert:[/]");
-                    AnsiConsole.MarkupLine($"[red]{Markup.Escape(alert)}[/]");
-                };
-            }
-
-            // Create conversation orchestrator and start conversation
-            AgentDataExtractor? dataExtractor = null;
-            if (settings.StructuredData?.Enabled == true)
-            {
-                var prompt = AgentDataExtractor.BuildSystemPrompt(settings.StructuredData);
-                var agent = AgentBuilder.CreateAgent(settings.LlmProvider, "DataExtractor", prompt);
-                dataExtractor = new AgentDataExtractor(agent, settings.StructuredData, sharedDoc, retryService, eventSink, dataPaths);
-            }
-
-            // Instantiate UI
             IUserInterface ui = new ConsoleUserInterface();
+            var builder = new ConversationPipelineBuilder(dataPaths, eventSink);
+            var pipeline = await AnsiConsole.Status()
+                .Spinner(Spinner.Known.Star)
+                .StartAsync("Building conversation pipeline...", _ =>
+                    builder.BuildAsync(
+                        settings,
+                        topic,
+                        cancellationToken: default,
+                        notify: message => AnsiConsole.MarkupLine($"[green]{Markup.Escape(message)}[/]")));
 
-            var conversationOrchestrator = new AgentConversationOrchestrator(
-                ui,
-                agentPersonas,
-                sharedDoc,
-                settings,
-                orchestrator,
-                editor,
-                dataExtractor,
-                factChecker);
-            
-            await conversationOrchestrator.StartConversationAsync(topic);
-
+            AnsiConsole.MarkupLine($"[bold]Personas:[/] {string.Join(", ", pipeline.Personas.Select(p => Markup.Escape(p.Name)))}\n");
+            await pipeline.CreateConversation(ui).StartConversationAsync(topic);
             AnsiConsole.MarkupLine("\n[bold green]Thank you for using CoffeeTalk! ☕[/]");
         }
         catch (OperationCanceledException ex)


### PR DESCRIPTION
Implements issue #91 and centralizes CLI/GUI conversation setup in a reusable ConversationPipelineBuilder.

- Applies dynamic persona augment/replace, Devil's Advocate, markdown tools/ToolsConfig, orchestrator, editor, fact checker, structured extractor, and per-conversation retry/event dependencies consistently.
- Routes fact-check alerts through the active UI and preserves cancellation.
- Adds focused feature-construction and CLI/GUI parity tests.

Tests: `dotnet test CoffeeTalk.Tests/CoffeeTalk.Tests.csproj`; `dotnet build CoffeeTalk/CoffeeTalk.CLI.csproj`