### PR TITLE
Move conversation lifecycle into session service

### DIFF
--- a/CoffeeTalk.Core/Services/AgentConversationOrchestrator.cs
+++ b/CoffeeTalk.Core/Services/AgentConversationOrchestrator.cs
@@ -53,6 +53,7 @@ public class AgentConversationOrchestrator
 
     public async Task StartConversationAsync(string topic, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         if (_personas.Count == 0)
         {
             await _ui.ShowErrorAsync("[red]No personas configured. Please add personas to appsettings.json[/]");
@@ -71,13 +72,21 @@ public class AgentConversationOrchestrator
         var conversationHistory = new List<string>();
         var currentMessage = $"Let's discuss: {topic}";
         
-        if (_useOrchestrator)
+        try
         {
-            await RunOrchestratedConversationAsync(topic, conversationHistory, currentMessage, cancellationToken);
+            if (_useOrchestrator)
+            {
+                await RunOrchestratedConversationAsync(topic, conversationHistory, currentMessage, cancellationToken);
+            }
+            else
+            {
+                await RunRoundRobinConversationAsync(conversationHistory, currentMessage, cancellationToken);
+            }
         }
-        else
+        catch (OperationCanceledException)
         {
-            await RunRoundRobinConversationAsync(conversationHistory, currentMessage, cancellationToken);
+            await TryAutoSaveAsync(CancellationToken.None);
+            throw;
         }
     }
 
@@ -154,6 +163,7 @@ public class AgentConversationOrchestrator
                 // Interactive Mode Check
                 if (_interactiveMode)
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
                     var (action, message) = await _ui.GetUserInterventionAsync();
                     if (action == "quit") break;
                     if (action == "inject" && !string.IsNullOrWhiteSpace(message))
@@ -169,7 +179,7 @@ public class AgentConversationOrchestrator
             catch (OperationCanceledException ex)
             {
                 System.Diagnostics.Trace.WriteLine($"[Orchestrator] Operation canceled: {ex.Message}", "Info");
-                await _ui.ShowErrorAsync("[red]❌ Operation canceled.[/]");
+                throw;
             }
             catch (TimeoutException ex)
             {
@@ -203,7 +213,7 @@ public class AgentConversationOrchestrator
             await _dataExtractor.ExtractAndSaveAsync(conversationHistory, cancellationToken);
         }
 
-        await TryAutoSaveAsync();
+        await TryAutoSaveAsync(cancellationToken);
     }
 
     private async Task RunRoundRobinConversationAsync(List<string> conversationHistory, string currentMessage, CancellationToken cancellationToken)
@@ -268,11 +278,12 @@ public class AgentConversationOrchestrator
                     // Interactive Mode Check
                     if (_interactiveMode)
                     {
+                        cancellationToken.ThrowIfCancellationRequested();
                         var (action, message) = await _ui.GetUserInterventionAsync();
                         if (action == "quit")
                         {
                             await _ui.ShowMessageAsync($"\n[yellow]Conversation manually ended by user.[/]");
-                            await TryAutoSaveAsync();
+                            await TryAutoSaveAsync(cancellationToken);
                             return;
                         }
                         if (action == "inject" && !string.IsNullOrWhiteSpace(message))
@@ -296,17 +307,17 @@ public class AgentConversationOrchestrator
 
                         if (_dataExtractor != null)
                         {
-                            await _dataExtractor.ExtractAndSaveAsync(conversationHistory);
+                            await _dataExtractor.ExtractAndSaveAsync(conversationHistory, cancellationToken);
                         }
 
-                        await TryAutoSaveAsync();
+                        await TryAutoSaveAsync(cancellationToken);
                         return;
                     }
                 }
                 catch (OperationCanceledException ex)
                     {
                         System.Diagnostics.Trace.WriteLine($"[RoundRobin] Operation canceled: {ex.Message}", "Info");
-                        await _ui.ShowErrorAsync("[red]❌ Operation canceled.[/]");
+                    throw;
                     }
                     catch (TimeoutException ex)
                     {
@@ -336,10 +347,10 @@ public class AgentConversationOrchestrator
 
         if (_dataExtractor != null)
         {
-            await _dataExtractor.ExtractAndSaveAsync(conversationHistory);
+            await _dataExtractor.ExtractAndSaveAsync(conversationHistory, cancellationToken);
         }
 
-        await TryAutoSaveAsync();
+        await TryAutoSaveAsync(cancellationToken);
     }
 
     private async Task RunEditorIntervention(List<string> conversationHistory, CancellationToken cancellationToken)
@@ -412,11 +423,11 @@ public class AgentConversationOrchestrator
         return completionIndicators.Any(indicator => lowerResponse.Contains(indicator));
     }
 
-    private async Task TryAutoSaveAsync()
+    private async Task TryAutoSaveAsync(CancellationToken cancellationToken)
     {
         try
         {
-            var path = await _doc.SaveToFileAsync("conversation.md");
+            var path = await _doc.SaveToFileAsync("conversation.md", cancellationToken);
 
             await _ui.ShowMessageAsync($"[green]✓ Auto-saved collaborative document ({Escape(path)})[/]");
         }
@@ -474,6 +485,10 @@ public class AgentConversationOrchestrator
                     await _ui.ShowMessageAsync("[dim]History summarized to save tokens.[/]");
                 }
             });
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception)
         {

--- a/CoffeeTalk.Core/Services/AgentDataExtractor.cs
+++ b/CoffeeTalk.Core/Services/AgentDataExtractor.cs
@@ -87,7 +87,7 @@ Based on the schema description '{_config.SchemaDescription}', extract the data 
 
             var outputPath = _paths.ResolveDataPath(_config.OutputFile, "data.json");
             Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
-            await File.WriteAllTextAsync(outputPath, json);
+            await File.WriteAllTextAsync(outputPath, json, cancellationToken);
         }
         catch (OperationCanceledException)
         {

--- a/CoffeeTalk.Core/Services/AgentEditor.cs
+++ b/CoffeeTalk.Core/Services/AgentEditor.cs
@@ -95,7 +95,7 @@ Prefer replacing existing sections over appending new content. Use ReplaceSectio
         if (_rateLimiter != null)
         {
             var estimatedTokens = _rateLimiter.EstimateTokens(prompt);
-            await _rateLimiter.ThrottleAsync(estimatedTokens);
+            await _rateLimiter.ThrottleAsync(estimatedTokens, cancellationToken);
         }
 
         // Execute with retry logic

--- a/CoffeeTalk.Core/Services/AgentFactChecker.cs
+++ b/CoffeeTalk.Core/Services/AgentFactChecker.cs
@@ -52,7 +52,7 @@ Output Format:
         {
             if (_rateLimiter != null)
             {
-                await _rateLimiter.ThrottleAsync(_rateLimiter.EstimateTokens(prompt));
+                await _rateLimiter.ThrottleAsync(_rateLimiter.EstimateTokens(prompt), cancellationToken);
             }
 
             var response = await _retryService.ExecuteAsync(

--- a/CoffeeTalk.Core/Services/AgentPersona.cs
+++ b/CoffeeTalk.Core/Services/AgentPersona.cs
@@ -79,7 +79,7 @@ public class AgentPersona
         var estimatedTokens = _rateLimiter?.EstimateTokens(contextMessage) ?? 0;
         if (_rateLimiter != null)
         {
-            await _rateLimiter.ThrottleAsync(estimatedTokens);
+            await _rateLimiter.ThrottleAsync(estimatedTokens, cancellationToken);
         }
 
         // Execute with retry logic for rate limiting (HTTP 429)
@@ -94,7 +94,7 @@ public class AgentPersona
         }
         catch (OperationCanceledException)
         {
-            responseText = $"Error: Operation was canceled.";
+            throw;
         }
         catch (TimeoutException)
         {

--- a/CoffeeTalk.Core/Services/CollaborativeMarkdownDocument.cs
+++ b/CoffeeTalk.Core/Services/CollaborativeMarkdownDocument.cs
@@ -251,7 +251,7 @@ public class CollaborativeMarkdownDocument
         }
     }
 
-    public async Task<string> SaveToFileAsync(string? path)
+    public async Task<string> SaveToFileAsync(string? path, CancellationToken cancellationToken = default)
     {
         string contentToWrite;
         lock (_lock)
@@ -261,7 +261,7 @@ public class CollaborativeMarkdownDocument
 
         var fullPath = _paths.ResolveExportPath(path, "conversation.md");
         Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
-        await File.WriteAllTextAsync(fullPath, contentToWrite);
+        await File.WriteAllTextAsync(fullPath, contentToWrite, cancellationToken);
         return fullPath;
     }
 }

--- a/CoffeeTalk.Gui/Components/Pages/Conversation.razor
+++ b/CoffeeTalk.Gui/Components/Pages/Conversation.razor
@@ -5,6 +5,7 @@
 @namespace CoffeeTalk.Gui.Components
 @implements IDisposable
 @inject BlazorUserInterface UI
+@inject IConversationSessionService Session
 @inject AppState AppState
 @inject ISnackbar Snackbar
 @inject IDialogService DialogService
@@ -156,17 +157,26 @@
         UI.OnChange -= OnUiChanged;
     }
 
-    private void StopConversation() => UI.SubmitIntervention("quit", "");
+    private void StopConversation() => Session.Cancel();
     private void Submit(string action, string message)
     {
+        if (action == "quit")
+        {
+            Session.Cancel();
+            FeedbackMessage = "";
+            return;
+        }
         UI.SubmitIntervention(action, message);
         FeedbackMessage = "";
     }
 
     private void OnUiChanged()
     {
-        StateHasChanged();
-        _ = InvokeAsync(async () => { await ScrollToBottomAsync(); });
+        _ = InvokeAsync(async () =>
+        {
+            StateHasChanged();
+            await ScrollToBottomAsync();
+        });
     }
 
     private void OnChangeScrollToBottom() => _ = ScrollToBottomAsync();

--- a/CoffeeTalk.Gui/Components/Pages/Home.razor
+++ b/CoffeeTalk.Gui/Components/Pages/Home.razor
@@ -5,17 +5,12 @@
 @using CoffeeTalk.Gui.Services
 @using CoffeeTalk.Gui.Components.Pages
 @using MudBlazor
-@using Microsoft.Extensions.Logging
 @namespace CoffeeTalk.Gui.Components.Pages
 
 @inject AppState AppState
-@inject BlazorUserInterface UI
 @inject NavigationManager Navigation
-@inject ILogger<Home> Logger
 @inject ConversationHistoryService History
-@inject IApplicationDataPathResolver DataPaths
-@inject IOperationalEventSink OperationalEvents
-@inject ConversationPipelineBuilder PipelineBuilder
+@inject IConversationSessionService Session
 
 
 <MudContainer MaxWidth="MaxWidth.Medium" Class="mt-8">
@@ -110,14 +105,11 @@
     </MudGrid>
 </MudContainer>
 
-@implements IDisposable
 @code {
     private string Topic = "";
 
     private IReadOnlyCollection<object> SelectedPersonas { get; set; } = new List<object>();
     private IReadOnlyList<ConversationRecord> _recentConversations = Array.Empty<ConversationRecord>();
-    private Task? _conversationTask;
-    private CancellationTokenSource? _cts;
 
     protected override void OnInitialized()
     {
@@ -126,66 +118,18 @@
         _recentConversations = History.Recent();
     }
 
-    private async Task StartConversation()
+    private void StartConversation()
     {
         if (string.IsNullOrWhiteSpace(Topic)) return;
         if (SelectedPersonas == null || SelectedPersonas.Count < 2) return;
 
-        // Cancel any existing conversation
-        _cts?.Cancel();
-        _cts?.Dispose();
-        _cts = new CancellationTokenSource();
-
-        // Navigate to conversation page first
+        Session.Start(Topic, SelectedPersonas.Cast<PersonaConfig>().ToList());
         Navigation.NavigateTo("/conversation");
-
-        // Run the conversation, tracking the task for cancellation
-        _conversationTask = RunConversationAsync(_cts.Token);
     }
 
-    private async Task RunConversationAsync(CancellationToken ct)
+    private async Task ResumeConversation(ConversationRecord conversation)
     {
-        try
-        {
-            var settings = AppState.Settings;
-            var activePersonasConfig = SelectedPersonas.Cast<PersonaConfig>().ToList();
-            var pipeline = await PipelineBuilder.BuildAsync(settings, Topic, activePersonasConfig, ct);
-            await pipeline.CreateConversation(UI).StartConversationAsync(Topic, ct);
-        }
-        catch (OperationCanceledException)
-        {
-            // Conversation was cancelled
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "Error during conversation orchestration");
-            await UI.ShowErrorAsync("An error occurred while starting the conversation. Please check your configuration and try again.");
-        }
-        finally
-        {
-            History.Add(new ConversationRecord
-            {
-                Topic = Topic,
-                StartedAt = UI.ConversationStartedAt ?? DateTime.Now,
-                CompletedAt = DateTime.Now,
-                Status = UI.StopRequested ? "Stopped" : "Completed",
-                MessageCount = UI.Messages.Count,
-                Personas = UI.ConversationParticipants.ToList(),
-                Messages = UI.Messages.ToList()
-            });
-            UI.EndConversation();
-        }
-    }
-
-    public void Dispose()
-    {
-        _cts?.Cancel();
-        _cts?.Dispose();
-    }
-
-    private void ResumeConversation(ConversationRecord conversation)
-    {
-        UI.LoadConversation(conversation);
+        await Session.LoadConversationAsync(conversation);
         Navigation.NavigateTo("/conversation");
     }
 }

--- a/CoffeeTalk.Gui/Program.cs
+++ b/CoffeeTalk.Gui/Program.cs
@@ -22,6 +22,8 @@ class Program
         appBuilder.Services.AddSingleton<BlazorOperationalEventSink>();
         appBuilder.Services.AddSingleton<IOperationalEventSink>(sp => sp.GetRequiredService<BlazorOperationalEventSink>());
         appBuilder.Services.AddSingleton<ConversationPipelineBuilder>();
+        appBuilder.Services.AddSingleton<ConversationSessionService>();
+        appBuilder.Services.AddSingleton<IConversationSessionService>(sp => sp.GetRequiredService<ConversationSessionService>());
 
         // Register the UI as a singleton so it can be shared between the background task and the pages
         appBuilder.Services.AddSingleton<BlazorUserInterface>();

--- a/CoffeeTalk.Gui/Services/BlazorUserInterface.cs
+++ b/CoffeeTalk.Gui/Services/BlazorUserInterface.cs
@@ -82,9 +82,9 @@ namespace CoffeeTalk.Gui.Services
                     return _interventionTcs.Task; // Already waiting for intervention
 
                 IsInterventionRequired = true;
+                _interventionTcs = new TaskCompletionSource<(string Action, string Message)>(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
                 NotifyStateChanged();
-
-                _interventionTcs = new TaskCompletionSource<(string Action, string Message)>();
                 return _interventionTcs.Task;
             }
         }
@@ -104,6 +104,23 @@ namespace CoffeeTalk.Gui.Services
             }
             IsInterventionRequired = false;
             NotifyStateChanged();
+        }
+
+        public void CancelIntervention(bool markStop = true)
+        {
+            TaskCompletionSource<(string Action, string Message)>? tcs;
+            lock (_tcsLock)
+            {
+                tcs = _interventionTcs;
+                _interventionTcs = null;
+                IsInterventionRequired = false;
+                if (markStop)
+                    StopRequested = true;
+            }
+
+            tcs?.TrySetCanceled();
+            if (tcs is not null)
+                NotifyStateChanged();
         }
 
         public Task SetStatusAsync(string status)
@@ -156,26 +173,55 @@ namespace CoffeeTalk.Gui.Services
             IsConversationRunning = false;
             CurrentThinkingPersona = null;
             IsInterventionRequired = false;
+            CancelIntervention(false);
+            NotifyStateChanged();
+        }
+
+        public void ResetForNewConversation()
+        {
+            CancelIntervention();
+            lock (_messagesLock)
+                Messages.Clear();
+            StopRequested = false;
+            ConversationTopic = null;
+            ConversationParticipants = Array.Empty<string>();
+            ConversationMode = null;
+            ConversationStartedAt = null;
+            IsConversationRunning = false;
+            StatusMessage = null;
+            IsBusy = false;
+            CurrentThinkingPersona = null;
+            DocumentContent = "";
+            DocumentMarkdown = "";
             NotifyStateChanged();
         }
 
         public void LoadConversation(ConversationRecord record)
         {
-            Messages.Clear();
-            Messages.AddRange(record.Messages.Select(message => new ChatMessage
+            lock (_messagesLock)
             {
-                Sender = message.Sender,
-                Content = message.Content,
-                IsSystem = message.IsSystem,
-                IsError = message.IsError,
-                IsDivider = message.IsDivider,
-                Timestamp = message.Timestamp
-            }));
+                Messages.Clear();
+                Messages.AddRange(record.Messages.Select(message => new ChatMessage
+                {
+                    Sender = message.Sender,
+                    Content = message.Content,
+                    IsSystem = message.IsSystem,
+                    IsError = message.IsError,
+                    IsDivider = message.IsDivider,
+                    Timestamp = message.Timestamp
+                }));
+            }
             ConversationTopic = record.Topic;
             ConversationParticipants = record.Personas;
             ConversationMode = "History";
             ConversationStartedAt = record.StartedAt;
             IsConversationRunning = false;
+            StopRequested = false;
+            StatusMessage = null;
+            IsBusy = false;
+            CurrentThinkingPersona = null;
+            DocumentContent = "";
+            DocumentMarkdown = "";
             NotifyStateChanged();
         }
 

--- a/CoffeeTalk.Gui/Services/ConversationSessionService.cs
+++ b/CoffeeTalk.Gui/Services/ConversationSessionService.cs
@@ -1,0 +1,178 @@
+using CoffeeTalk.Models;
+using CoffeeTalk.Services;
+using Microsoft.Extensions.Logging;
+using System.Text.Json;
+
+namespace CoffeeTalk.Gui.Services;
+
+public interface IConversationSessionService
+{
+    void Start(string topic, IReadOnlyCollection<PersonaConfig> personas);
+    void Cancel();
+    Task LoadConversationAsync(ConversationRecord record);
+}
+
+public sealed class ConversationSessionService : IConversationSessionService, IDisposable
+{
+    private readonly AppState _appState;
+    private readonly BlazorUserInterface _ui;
+    private readonly ConversationHistoryService _history;
+    private readonly ConversationPipelineBuilder _pipelineBuilder;
+    private readonly ILogger<ConversationSessionService> _logger;
+    private readonly object _gate = new();
+    private CancellationTokenSource? _cts;
+    private Task? _conversationTask;
+    private bool _disposed;
+
+    public ConversationSessionService(
+        AppState appState,
+        BlazorUserInterface ui,
+        ConversationHistoryService history,
+        ConversationPipelineBuilder pipelineBuilder,
+        ILogger<ConversationSessionService> logger)
+    {
+        _appState = appState;
+        _ui = ui;
+        _history = history;
+        _pipelineBuilder = pipelineBuilder;
+        _logger = logger;
+    }
+
+    public bool IsRunning
+    {
+        get
+        {
+            lock (_gate)
+                return _conversationTask is { IsCompleted: false };
+        }
+    }
+
+    public void Start(string topic, IReadOnlyCollection<PersonaConfig> personas)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(topic);
+        ArgumentNullException.ThrowIfNull(personas);
+
+        CancellationTokenSource cts;
+        Task? previousTask;
+        lock (_gate)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            previousTask = _conversationTask;
+            _cts?.Cancel();
+            cts = _cts = new CancellationTokenSource();
+            _conversationTask = RunAfterPreviousAsync(previousTask, topic, personas.ToList(), cts);
+        }
+    }
+
+    public void Cancel()
+    {
+        lock (_gate)
+            _cts?.Cancel();
+        _ui.CancelIntervention();
+    }
+
+    public async Task LoadConversationAsync(ConversationRecord record)
+    {
+        while (true)
+        {
+            Task? activeTask;
+            lock (_gate)
+            {
+                activeTask = _conversationTask;
+                _cts?.Cancel();
+            }
+            _ui.CancelIntervention();
+
+            if (activeTask is not null)
+                await activeTask.ConfigureAwait(false);
+
+            lock (_gate)
+            {
+                if (ReferenceEquals(_conversationTask, activeTask))
+                {
+                    _ui.LoadConversation(record);
+                    return;
+                }
+            }
+        }
+    }
+
+    private async Task RunAfterPreviousAsync(
+        Task? previousTask,
+        string topic,
+        List<PersonaConfig> personas,
+        CancellationTokenSource cts)
+    {
+        if (previousTask is not null)
+            await previousTask.ConfigureAwait(false);
+
+        _ui.ResetForNewConversation();
+        await RunAsync(topic, personas, cts);
+    }
+
+    private async Task RunAsync(string topic, List<PersonaConfig> personas, CancellationTokenSource cts)
+    {
+        try
+        {
+            var pipeline = await _pipelineBuilder.BuildAsync(_appState.Settings, topic, personas, cts.Token);
+            await pipeline.CreateConversation(_ui).StartConversationAsync(topic, cts.Token);
+        }
+        catch (OperationCanceledException) when (cts.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error during conversation orchestration");
+            await _ui.ShowErrorAsync("An error occurred while starting the conversation. Please check your configuration and try again.");
+        }
+        finally
+        {
+            lock (_gate)
+            {
+                try
+                {
+                    _history.Add(new ConversationRecord
+                    {
+                        Topic = topic,
+                        StartedAt = _ui.ConversationStartedAt ?? DateTime.Now,
+                        CompletedAt = DateTime.Now,
+                        Status = cts.IsCancellationRequested || _ui.StopRequested ? "Stopped" : "Completed",
+                        MessageCount = _ui.Messages.Count,
+                        Personas = _ui.ConversationParticipants.ToList(),
+                        Messages = _ui.Messages.ToList()
+                    });
+                }
+                catch (JsonException ex)
+                {
+                    _logger.LogError(ex, "Failed to serialize conversation history for {Topic}", topic);
+                }
+                catch (IOException ex)
+                {
+                    _logger.LogError(ex, "Failed to write conversation history for {Topic}", topic);
+                }
+                catch (UnauthorizedAccessException ex)
+                {
+                    _logger.LogError(ex, "Failed to persist conversation history for {Topic}", topic);
+                }
+                if (ReferenceEquals(_cts, cts))
+                {
+                    _ui.EndConversation();
+                    _conversationTask = null;
+                    _cts = null;
+                }
+            }
+            cts.Dispose();
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (_gate)
+        {
+            if (_disposed) return;
+            _disposed = true;
+            _cts?.Cancel();
+        }
+        _ui.CancelIntervention();
+    }
+}

--- a/CoffeeTalk.Tests/BlazorUserInterfaceTests.cs
+++ b/CoffeeTalk.Tests/BlazorUserInterfaceTests.cs
@@ -47,4 +47,66 @@ public class BlazorUserInterfaceTests
         Assert.Equal("ok", result.Message);
         Assert.False(ui.IsInterventionRequired);
     }
+
+    [Fact]
+    public async Task GetUserInterventionAsync_ShouldReusePendingIntervention()
+    {
+        var ui = new BlazorUserInterface();
+
+        var first = ui.GetUserInterventionAsync();
+        var second = ui.GetUserInterventionAsync();
+
+        Assert.Same(first, second);
+        ui.SubmitIntervention("continue", "ok");
+        await first;
+    }
+
+    [Fact]
+    public async Task CancelIntervention_ShouldCompletePendingTaskAsCanceled()
+    {
+        var ui = new BlazorUserInterface();
+        var intervention = ui.GetUserInterventionAsync();
+
+        ui.CancelIntervention();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => intervention);
+        Assert.False(ui.IsInterventionRequired);
+        Assert.True(ui.StopRequested);
+    }
+
+    [Fact]
+    public async Task ResetForNewConversation_ShouldClearConversationScopedState()
+    {
+        var ui = new BlazorUserInterface();
+        await ui.ShowConversationHeaderAsync("first", new[] { "A", "B" }, "Mode", false);
+        await ui.ShowAgentResponseAsync("A", "old message");
+        await ui.ShowDocumentPreviewAsync("# old");
+
+        ui.ResetForNewConversation();
+
+        Assert.Empty(ui.Messages);
+        Assert.Null(ui.ConversationTopic);
+        Assert.Empty(ui.ConversationParticipants);
+        Assert.Empty(ui.DocumentMarkdown);
+        Assert.False(ui.IsConversationRunning);
+    }
+
+    [Fact]
+    public async Task LoadConversation_ShouldPreserveHistoryState()
+    {
+        var ui = new BlazorUserInterface();
+        var record = new ConversationRecord
+        {
+            Topic = "history",
+            Personas = new List<string> { "A", "B" },
+            Messages = new List<ChatMessage> { new() { Sender = "A", Content = "saved" } }
+        };
+
+        ui.LoadConversation(record);
+
+        Assert.Equal("history", ui.ConversationTopic);
+        Assert.Single(ui.Messages);
+        Assert.Equal("saved", ui.Messages[0].Content);
+        await Task.CompletedTask;
+    }
 }

--- a/CoffeeTalk.Tests/ConversationComponentTests.cs
+++ b/CoffeeTalk.Tests/ConversationComponentTests.cs
@@ -5,6 +5,7 @@ using CoffeeTalk.Gui.Services;
 using CoffeeTalk.Services;
 using Microsoft.Extensions.DependencyInjection;
 using MudBlazor.Services;
+using Moq;
 
 namespace CoffeeTalk.Tests;
 
@@ -23,6 +24,7 @@ public class ConversationComponentTests : TestContext
 
         var ui = new BlazorUserInterface();
         Services.AddSingleton<BlazorUserInterface>(ui);
+        Services.AddSingleton<IConversationSessionService>(new Mock<IConversationSessionService>().Object);
 
         ui.Messages.Add(new ChatMessage { Sender = "Agent", Content = "Hello" });
 


### PR DESCRIPTION
## Summary
- move conversation task, cancellation, and history finalization into a long-lived GUI session service
- reset conversation-scoped UI state while preserving explicit history loads
- propagate cancellation through orchestration, retries, rate limiting, extraction, and autosave
- complete pending intervention tasks and marshal renderer updates safely

## Issues
Closes #22
Closes #35
Closes #36
Closes #92

## Validation
-   CoffeeTalk.Core -> /Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-fantastic-chainsaw/CoffeeTalk.Core/bin/Debug/net9.0/CoffeeTalk.Core.dll
/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-fantastic-chainsaw/CoffeeTalk.Gui/Components/Pages/Settings.razor(143,22): warning CS0618: 'IDialogService.Show<TComponent>(string?, DialogParameters)' is obsolete: 'Use ShowAsync instead. This will be removed in future major version.' [/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-fantastic-chainsaw/CoffeeTalk.Gui/CoffeeTalk.Gui.csproj]
/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-fantastic-chainsaw/CoffeeTalk.Gui/Components/Pages/Settings.razor(146,14): warning CS8602: Dereference of a possibly null reference. [/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-fantastic-chainsaw/CoffeeTalk.Gui/CoffeeTalk.Gui.csproj]
/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-fantastic-chainsaw/CoffeeTalk.Gui/Components/Pages/Settings.razor(148,44): warning CS8600: Converting null literal or possible null value to non-nullable type. [/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-fantastic-chainsaw/CoffeeTalk.Gui/CoffeeTalk.Gui.csproj]
/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-fantastic-chainsaw/CoffeeTalk.Gui/Components/Pages/Settings.razor(148,44): warning CS8604: Possible null reference argument for parameter 'item' in 'void List<PersonaConfig>.Add(PersonaConfig item)'. [/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-fantastic-chainsaw/CoffeeTalk.Gui/CoffeeTalk.Gui.csproj]
/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-fantastic-chainsaw/CoffeeTalk.Gui/Components/Pages/Settings.razor(156,22): warning CS0618: 'IDialogService.Show<TComponent>(string?, DialogParameters)' is obsolete: 'Use ShowAsync instead. This will be removed in future major version.' [/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-fantastic-chainsaw/CoffeeTalk.Gui/CoffeeTalk.Gui.csproj]
/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-fantastic-chainsaw/CoffeeTalk.Gui/Components/Pages/Conversation.razor(249,22): warning CS0618: 'IDialogService.Show<TComponent>(string?, DialogParameters)' is obsolete: 'Use ShowAsync instead. This will be removed in future major version.' [/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-fantastic-chainsaw/CoffeeTalk.Gui/CoffeeTalk.Gui.csproj]
/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-fantastic-chainsaw/CoffeeTalk.Gui/Components/Pages/Conversation.razor(251,14): warning CS8602: Dereference of a possibly null reference. [/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-fantastic-chainsaw/CoffeeTalk.Gui/CoffeeTalk.Gui.csproj]
/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-fantastic-chainsaw/CoffeeTalk.Gui/Components/Pages/Conversation.razor(263,20): warning CS0219: The variable 'mimeType' is assigned but its value is never used [/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-fantastic-chainsaw/CoffeeTalk.Gui/CoffeeTalk.Gui.csproj]
/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-fantastic-chainsaw/CoffeeTalk.Gui/Components/Pages/Conversation.razor(148,21): warning CS0649: Field 'Conversation._exportFormat' is never assigned to, and will always have its default value null [/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-fantastic-chainsaw/CoffeeTalk.Gui/CoffeeTalk.Gui.csproj]
/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-fantastic-chainsaw/CoffeeTalk.Gui/Components/ExportDialog.razor(1,1): warning MUD0002: Illegal Attribute 'Orientation' on 'MudRadioGroup' using pattern 'LowerCase' source location '(239,8)-(239,70)' (https://mudblazor.com/features/analyzers) [/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-fantastic-chainsaw/CoffeeTalk.Gui/CoffeeTalk.Gui.csproj]
/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-fantastic-chainsaw/CoffeeTalk.Gui/Components/MainLayout.razor(1,1): warning MUD0002: Illegal Attribute 'Link' on 'MudIconButton' using pattern 'LowerCase' source location '(389,20)-(389,103)' (https://mudblazor.com/features/analyzers) [/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-fantastic-chainsaw/CoffeeTalk.Gui/CoffeeTalk.Gui.csproj]
/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-fantastic-chainsaw/CoffeeTalk.Gui/Components/Pages/Conversation.razor(1,1): warning MUD0002: Illegal Attribute 'Title' on 'MudIconButton' using pattern 'LowerCase' source location '(1042,28)-(1042,87)' (https://mudblazor.com/features/analyzers) [/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-fantastic-chainsaw/CoffeeTalk.Gui/CoffeeTalk.Gui.csproj]
/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-fantastic-chainsaw/CoffeeTalk.Gui/Components/Pages/Home.razor(1,1): warning MUD0002: Illegal Attribute 'MultiSelection' on 'MudChipSet' using pattern 'LowerCase' source location '(1278,36)-(1278,99)' (https://mudblazor.com/features/analyzers) [/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-fantastic-chainsaw/CoffeeTalk.Gui/CoffeeTalk.Gui.csproj]
/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-fantastic-chainsaw/CoffeeTalk.Gui/Components/Pages/Settings.razor(1,1): warning MUD0002: Illegal Attribute 'Nullable' on 'MudNumericField' using pattern 'LowerCase' source location '(2409,8)-(2409,67)' (https://mudblazor.com/features/analyzers) [/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-fantastic-chainsaw/CoffeeTalk.Gui/CoffeeTalk.Gui.csproj]
/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-fantastic-chainsaw/CoffeeTalk.Gui/Components/Pages/Settings.razor(1,1): warning MUD0002: Illegal Attribute 'Nullable' on 'MudNumericField' using pattern 'LowerCase' source location '(2434,8)-(2434,67)' (https://mudblazor.com/features/analyzers) [/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-fantastic-chainsaw/CoffeeTalk.Gui/CoffeeTalk.Gui.csproj]
  CoffeeTalk.Gui -> /Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-fantastic-chainsaw/CoffeeTalk.Gui/bin/Debug/net9.0/CoffeeTalk.Gui.dll
/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-fantastic-chainsaw/CoffeeTalk.Tests/ConversationComponentTests.cs(12,43): warning CS0618: 'TestContext' is obsolete: 'Use BunitContext instead. TestContext will be removed in a future release.' (https://bunit.dev/docs/migrations) [/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-fantastic-chainsaw/CoffeeTalk.Tests/CoffeeTalk.Tests.csproj]
  CoffeeTalk.Tests -> /Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-fantastic-chainsaw/CoffeeTalk.Tests/bin/Debug/net9.0/CoffeeTalk.Tests.dll
Test run for /Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-fantastic-chainsaw/CoffeeTalk.Tests/bin/Debug/net9.0/CoffeeTalk.Tests.dll (.NETCoreApp,Version=v9.0)
VSTest version 18.0.1 (arm64)

Starting test execution, please wait...
A total of 1 test files matched the specified pattern.

Passed!  - Failed:     0, Passed:    35, Skipped:     0, Total:    35, Duration: 133 ms - CoffeeTalk.Tests.dll (net9.0) (35 passed)
- two independent read-only code-review passes completed