### PR TITLE
Add final regression coverage and close backlog

### DIFF
--- a/CoffeeTalk.Core/Services/AgentDataExtractor.cs
+++ b/CoffeeTalk.Core/Services/AgentDataExtractor.cs
@@ -13,7 +13,6 @@ public class AgentDataExtractor
     private readonly StructuredDataConfig _config;
     private readonly CollaborativeMarkdownDocument _doc;
     private readonly IApplicationDataPathResolver _paths;
- private readonly System.Diagnostics.TextWriterTraceListener? _tracer;
  private readonly IRetryService _retryService;
  private readonly IOperationalEventSink _eventSink;
 
@@ -31,9 +30,6 @@ public class AgentDataExtractor
      _paths = paths ?? new ApplicationDataPathResolver();
      _retryService = retryService;
      _eventSink = eventSink ?? NullOperationalEventSink.Instance;
-     // Use Trace for logging without external dependencies
-     _tracer = new System.Diagnostics.TextWriterTraceListener(System.Console.Error);
-     System.Diagnostics.Trace.Listeners.Add(_tracer);
  }
 
  public AgentDataExtractor(AIAgent agent, StructuredDataConfig config, CollaborativeMarkdownDocument doc, IApplicationDataPathResolver? paths = null)

--- a/CoffeeTalk.Gui/Components/Pages/Settings.razor
+++ b/CoffeeTalk.Gui/Components/Pages/Settings.razor
@@ -131,6 +131,7 @@
 
     protected override void OnInitialized()
     {
+        AppState.Settings.RateLimit ??= new RateLimitConfig();
         AppState.Settings.Editor ??= new EditorConfig();
         AppState.Settings.DynamicPersonas ??= new DynamicPersonasConfig();
         AppState.Settings.Tools ??= new ToolsConfig();

--- a/CoffeeTalk.Gui/Services/ConversationSessionService.cs
+++ b/CoffeeTalk.Gui/Services/ConversationSessionService.cs
@@ -62,6 +62,7 @@ public sealed class ConversationSessionService : IConversationSessionService, ID
             cts = _cts = new CancellationTokenSource();
             _conversationTask = RunAfterPreviousAsync(previousTask, topic, personas.ToList(), cts);
         }
+        _ui.CancelIntervention(false);
     }
 
     public void Cancel()

--- a/CoffeeTalk.Tests/AgentDataExtractorTests.cs
+++ b/CoffeeTalk.Tests/AgentDataExtractorTests.cs
@@ -1,0 +1,32 @@
+using CoffeeTalk.Models;
+using CoffeeTalk.Services;
+
+namespace CoffeeTalk.Tests;
+
+public sealed class AgentDataExtractorTests
+{
+    [Fact]
+    public void BuildSystemPrompt_ContainsConfiguredSchemaAndJsonOnlyInstruction()
+    {
+        var prompt = AgentDataExtractor.BuildSystemPrompt(
+            new StructuredDataConfig { SchemaDescription = "a contact record" });
+
+        Assert.Contains("a contact record", prompt);
+        Assert.Contains("ONLY valid JSON", prompt);
+    }
+
+    [Fact]
+    public async Task ExtractAndSaveAsync_PropagatesCancellationBeforeAgentCall()
+    {
+        var agent = new TestAIAgent("unused");
+        var extractor = new AgentDataExtractor(
+            agent,
+            new StructuredDataConfig(),
+            new CollaborativeMarkdownDocument());
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            extractor.ExtractAndSaveAsync(new List<string>(), cancellation.Token));
+    }
+}

--- a/CoffeeTalk.Tests/AgentEditorTests.cs
+++ b/CoffeeTalk.Tests/AgentEditorTests.cs
@@ -1,0 +1,25 @@
+using CoffeeTalk.Models;
+using CoffeeTalk.Services;
+using Microsoft.Agents.AI;
+using Moq;
+
+namespace CoffeeTalk.Tests;
+
+public sealed class AgentEditorTests
+{
+    [Fact]
+    public async Task ReviewAndEditAsync_ReturnsExplicitEmptyDocumentResultWithoutCallingAgent()
+    {
+        var agent = new Mock<AIAgent>(MockBehavior.Strict);
+        var editor = new AgentEditor(
+            agent.Object,
+            new EditorConfig(),
+            new CollaborativeMarkdownDocument(),
+            null);
+
+        var result = await editor.ReviewAndEditAsync("context");
+
+        Assert.Equal("Document is empty - nothing to edit yet.", result);
+        agent.VerifyNoOtherCalls();
+    }
+}

--- a/CoffeeTalk.Tests/AgentFactCheckerTests.cs
+++ b/CoffeeTalk.Tests/AgentFactCheckerTests.cs
@@ -1,0 +1,35 @@
+using CoffeeTalk.Services;
+
+namespace CoffeeTalk.Tests;
+
+public sealed class AgentFactCheckerTests
+{
+    [Fact]
+    public async Task CheckAsync_SkipsShortMessages()
+    {
+        var agent = new TestAIAgent("unused");
+        var checker = new AgentFactChecker(agent, null);
+
+        await checker.CheckAsync("too short");
+
+        Assert.Equal(0, agent.Calls);
+    }
+
+    [Fact]
+    public async Task CheckAsync_RaisesAlertForFlaggedClaims()
+    {
+        var checker = new AgentFactChecker(
+            new TestAIAgent("FLAG: verify this claim"),
+            null);
+        string? alert = null;
+        checker.OnFactCheckAlert += message =>
+        {
+            alert = message;
+            return Task.CompletedTask;
+        };
+
+        await checker.CheckAsync("This is a sufficiently long statement to verify.");
+
+        Assert.Equal("FLAG: verify this claim", alert);
+    }
+}

--- a/CoffeeTalk.Tests/AgentOrchestratorTests.cs
+++ b/CoffeeTalk.Tests/AgentOrchestratorTests.cs
@@ -1,0 +1,19 @@
+using CoffeeTalk.Models;
+using CoffeeTalk.Services;
+
+namespace CoffeeTalk.Tests;
+
+public sealed class AgentOrchestratorTests
+{
+    [Fact]
+    public void BuildSystemPrompt_ListsPersonasAndDecisionFormat()
+    {
+        var prompt = AgentOrchestrator.BuildSystemPrompt(
+            new OrchestratorConfig { BaseSystemPrompt = "Base instructions" },
+            new List<AgentPersona>());
+
+        Assert.Contains("Base instructions", prompt);
+        Assert.Contains("CONCLUDE", prompt);
+        Assert.Contains("Line 1", prompt);
+    }
+}

--- a/CoffeeTalk.Tests/AgentPersonaGeneratorTests.cs
+++ b/CoffeeTalk.Tests/AgentPersonaGeneratorTests.cs
@@ -1,0 +1,41 @@
+using CoffeeTalk.Models;
+using CoffeeTalk.Services;
+using Microsoft.Agents.AI;
+
+namespace CoffeeTalk.Tests;
+
+public sealed class AgentPersonaGeneratorTests
+{
+    [Fact]
+    public void BuildSystemPrompt_RequiresJsonAndExcludesBuiltInAgents()
+    {
+        var prompt = AgentPersonaGenerator.BuildSystemPrompt();
+
+        Assert.Contains("JSON ONLY", prompt);
+        Assert.Contains("DO NOT include them", prompt);
+        Assert.Contains("2 to 10 personas", prompt);
+    }
+
+    [Fact]
+    public async Task GenerateAsync_ClampsCountAndUsesUniqueFallbackNames()
+    {
+        var generator = new AgentPersonaGenerator(new TestAIAgent("not json"));
+
+        var personas = await generator.GenerateAsync("topic", 1, new[] { "ProductLead" });
+
+        Assert.Equal(2, personas.Count);
+        Assert.Equal(personas.Count, personas.Select(persona => persona.Name).Distinct(StringComparer.OrdinalIgnoreCase).Count());
+        Assert.DoesNotContain(personas, persona => persona.Name == "ProductLead");
+    }
+
+    [Fact]
+    public async Task GenerateAsync_ParsesJsonAndDeduplicatesNames()
+    {
+        var generator = new AgentPersonaGenerator(new TestAIAgent(
+            """[{"name":"Researcher!","systemPrompt":"You are Researcher, an evidence-focused analyst."},{"name":"researcher","systemPrompt":"You are Researcher, a second perspective."}]"""));
+
+        var personas = await generator.GenerateAsync("topic", 2);
+
+        Assert.Equal(new[] { "Researcher", "researcher2" }, personas.Select(persona => persona.Name));
+    }
+}

--- a/CoffeeTalk.Tests/AgentPersonaTests.cs
+++ b/CoffeeTalk.Tests/AgentPersonaTests.cs
@@ -1,0 +1,25 @@
+using CoffeeTalk.Models;
+using CoffeeTalk.Services;
+
+namespace CoffeeTalk.Tests;
+
+public sealed class AgentPersonaTests
+{
+    [Fact]
+    public async Task RespondAsync_ReturnsGenericFailureTextWithoutExceptionDetails()
+    {
+        const string secret = "internal-host-and-connection-details";
+        var persona = new AgentPersona(
+            new TestAIAgent(new InvalidOperationException(secret)),
+            new PersonaConfig { Name = "Analyst", SystemPrompt = "You are Analyst." },
+            new CollaborativeMarkdownDocument(),
+            null,
+            maxTurns: 2,
+            agentCount: 1);
+
+        var result = await persona.RespondAsync("topic", new List<string>());
+
+        Assert.Equal("Error: An unexpected error occurred.", result);
+        Assert.DoesNotContain(secret, result);
+    }
+}

--- a/CoffeeTalk.Tests/BlazorUserInterfaceTests.cs
+++ b/CoffeeTalk.Tests/BlazorUserInterfaceTests.cs
@@ -109,4 +109,16 @@ public class BlazorUserInterfaceTests
         Assert.Equal("saved", ui.Messages[0].Content);
         await Task.CompletedTask;
     }
+
+    [Fact]
+    public async Task EndConversation_CancelsPendingIntervention()
+    {
+        var ui = new BlazorUserInterface();
+        var intervention = ui.GetUserInterventionAsync();
+
+        ui.EndConversation();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => intervention);
+        Assert.False(ui.IsConversationRunning);
+    }
 }

--- a/CoffeeTalk.Tests/CollaborativeMarkdownDocumentTests.cs
+++ b/CoffeeTalk.Tests/CollaborativeMarkdownDocumentTests.cs
@@ -6,6 +6,38 @@ namespace CoffeeTalk.Tests;
 
 public class CollaborativeMarkdownDocumentTests
 {
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void InsertAfterHeading_InvalidContentDoesNotMutateDocument(string? content)
+    {
+        var document = new CollaborativeMarkdownDocument();
+        document.AddHeading("Position");
+        document.AppendParagraph("Keep this content.");
+        var before = document.Snapshot();
+
+        document.InsertAfterHeading("Position", content);
+
+        Assert.Equal(before, document.Snapshot());
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ReplaceSection_InvalidContentDoesNotMutateDocument(string? content)
+    {
+        var document = new CollaborativeMarkdownDocument();
+        document.AddHeading("Position");
+        document.AppendParagraph("Keep this content.");
+        var before = document.Snapshot();
+
+        document.ReplaceSection("Position", content);
+
+        Assert.Equal(before, document.Snapshot());
+    }
+
     [Fact]
     public void SetTitle_ShouldAddTitle_WhenDocumentIsEmpty()
     {

--- a/CoffeeTalk.Tests/ConfigurationServiceTests.cs
+++ b/CoffeeTalk.Tests/ConfigurationServiceTests.cs
@@ -24,4 +24,29 @@ public sealed class ConfigurationServiceTests
         Assert.Equal(false, loaded.Tools?.EnableFallbackJsonTools);
         Assert.Equal(false, loaded.Tools?.RequireToolsVerification);
     }
+
+    [Fact]
+    public async Task SaveAndLoad_AllowsPartialNullableSettings()
+    {
+        var resolver = new ApplicationDataPathResolver(
+            Path.Combine(Path.GetTempPath(), "coffeetalk-tests", Guid.NewGuid().ToString("N")));
+        var service = new ConfigurationService(resolver);
+
+        await service.SaveSettingsAsync(new AppSettings
+        {
+            RateLimit = null,
+            Tools = null,
+            Orchestrator = null,
+            Editor = null,
+            DynamicPersonas = null,
+            StructuredData = null,
+            Retry = null
+        });
+
+        var loaded = service.LoadConfiguration();
+
+        Assert.Null(loaded.RateLimit);
+        Assert.Null(loaded.Tools);
+        Assert.Null(loaded.Orchestrator);
+    }
 }

--- a/CoffeeTalk.Tests/ConversationExportServiceTests.cs
+++ b/CoffeeTalk.Tests/ConversationExportServiceTests.cs
@@ -74,6 +74,29 @@ public sealed class ConversationExportServiceTests
     }
 
     [Fact]
+    public void GenerateMarkdown_PreservesSpeakerOrderingForSystemAndDividerMessages()
+    {
+        var markdown = ConversationExportService.GenerateMarkdown(
+            "Topic",
+            null,
+            new[] { "A", "B" },
+            new[]
+            {
+                new ChatMessage { Sender = "System", Content = "started", IsSystem = true },
+                new ChatMessage { Sender = "A", Content = "first" },
+                new ChatMessage { Sender = "System", Content = "round", IsDivider = true },
+                new ChatMessage { Sender = "B", Content = "second" }
+            });
+
+        Assert.True(markdown.IndexOf("started", StringComparison.Ordinal) < markdown.IndexOf("first", StringComparison.Ordinal));
+        Assert.True(markdown.IndexOf("---", StringComparison.Ordinal) > markdown.IndexOf("first", StringComparison.Ordinal));
+        Assert.True(markdown.IndexOf("---", StringComparison.Ordinal) < markdown.IndexOf("second", StringComparison.Ordinal));
+        Assert.True(markdown.IndexOf("first", StringComparison.Ordinal) < markdown.IndexOf("second", StringComparison.Ordinal));
+        Assert.Contains("**System**", markdown);
+        Assert.Contains("---", markdown);
+    }
+
+    [Fact]
     public void GenerateJson_ProducesValidJsonWithAllMessages()
     {
         var messages = new[]

--- a/CoffeeTalk.Tests/OrchestratorTests.cs
+++ b/CoffeeTalk.Tests/OrchestratorTests.cs
@@ -2,6 +2,7 @@ using Xunit;
 using CoffeeTalk.Core.Interfaces;
 using CoffeeTalk.Services;
 using CoffeeTalk.Models;
+using CoffeeTalk.Gui.Services;
 using Microsoft.Agents.AI;
 using System.Threading.Tasks;
 using System.Collections.Generic;
@@ -31,5 +32,30 @@ public class OrchestratorTests
 
         // Assert
         mockUi.Verify(ui => ui.ShowErrorAsync(It.Is<string>(s => s.Contains("No personas configured"))), Times.Once);
+    }
+
+    [Fact]
+    public async Task StartConversationAsync_ShowsGenericErrorForUnexpectedOrchestratorFailure()
+    {
+        var ui = new BlazorUserInterface();
+        var persona = new AgentPersona(
+            new TestAIAgent(new InvalidOperationException("internal stack details")),
+            new PersonaConfig { Name = "Analyst", SystemPrompt = "You are Analyst." },
+            new CollaborativeMarkdownDocument(),
+            null,
+            maxTurns: 1,
+            agentCount: 1);
+        var settings = new AppSettings { MaxConversationTurns = 1 };
+        var orchestrator = new AgentConversationOrchestrator(
+            ui,
+            new List<AgentPersona> { persona },
+            new CollaborativeMarkdownDocument(),
+            settings);
+
+        await orchestrator.StartConversationAsync("topic");
+
+        Assert.Contains(ui.Messages, message =>
+            message.Content.Contains("An unexpected error occurred."));
+        Assert.DoesNotContain(ui.Messages, message => message.Content.Contains("internal stack details"));
     }
 }

--- a/CoffeeTalk.Tests/RateLimiterTests.cs
+++ b/CoffeeTalk.Tests/RateLimiterTests.cs
@@ -1,0 +1,56 @@
+using CoffeeTalk.Models;
+using CoffeeTalk.Services;
+
+namespace CoffeeTalk.Tests;
+
+public sealed class RateLimiterTests
+{
+    [Fact]
+    public async Task ThrottleAsync_ReservesRequestsAtomicallyUnderConcurrency()
+    {
+        var limiter = new RateLimiter(new RateLimitConfig { RequestsPerMinute = 1 });
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+
+        var tasks = Enumerable.Range(0, 20)
+            .Select(_ => limiter.ThrottleAsync(1, cancellation.Token))
+            .ToArray();
+
+        var results = await Task.WhenAll(tasks.Select(async task =>
+        {
+            try
+            {
+                await task;
+                return true;
+            }
+            catch (OperationCanceledException)
+            {
+                return false;
+            }
+        }));
+
+        Assert.Equal(1, results.Count(result => result));
+    }
+
+    [Fact]
+    public async Task ThrottleAsync_EnforcesConversationCaps()
+    {
+        var limiter = new RateLimiter(new RateLimitConfig
+        {
+            MaxRequestsPerConversation = 1,
+            MaxTokensPerConversation = 3
+        });
+
+        await limiter.ThrottleAsync(3);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => limiter.ThrottleAsync(1));
+    }
+
+    [Fact]
+    public void EstimateTokens_UsesConfiguredApproximationAndHandlesEmptyText()
+    {
+        var limiter = new RateLimiter(new RateLimitConfig { ApproxCharsPerToken = 2 });
+
+        Assert.Equal(2, limiter.EstimateTokens("abc"));
+        Assert.Equal(0, limiter.EstimateTokens(string.Empty));
+    }
+}

--- a/CoffeeTalk.Tests/TestAIAgent.cs
+++ b/CoffeeTalk.Tests/TestAIAgent.cs
@@ -1,0 +1,54 @@
+using System.Text.Json;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+
+namespace CoffeeTalk.Tests;
+
+internal sealed class TestAIAgent : AIAgent
+{
+    private readonly Func<AgentRunResponse> _response;
+    public int Calls { get; private set; }
+
+    public TestAIAgent(Func<AgentRunResponse> response)
+    {
+        _response = response;
+    }
+
+    public TestAIAgent(string response)
+        : this(() => new AgentRunResponse(new ChatMessage(ChatRole.Assistant, response)))
+    {
+    }
+
+    public TestAIAgent(Exception exception)
+        : this(() => throw exception)
+    {
+    }
+
+    public override AgentThread GetNewThread() => throw new NotSupportedException();
+
+    public override AgentThread DeserializeThread(
+        JsonElement serializedThread,
+        System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
+        => throw new NotSupportedException();
+
+    public override Task<AgentRunResponse> RunAsync(
+        IEnumerable<ChatMessage> messages,
+        AgentThread? thread = null,
+        AgentRunOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        Calls++;
+        return Task.FromResult(_response());
+    }
+
+    public override async IAsyncEnumerable<AgentRunResponseUpdate> RunStreamingAsync(
+        IEnumerable<ChatMessage> messages,
+        AgentThread? thread = null,
+        AgentRunOptions? options = null,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        await Task.CompletedTask;
+        yield break;
+    }
+}


### PR DESCRIPTION
## Summary
- add focused regression coverage for critical services, rate limits, nullable settings, generic errors, exports, document no-op semantics, and lifecycle cancellation
- initialize nullable rate-limit settings safely in the GUI
- cancel stale interactive intervention without stopping a newly started conversation
- remove per-instance trace listener accumulation

## Validation
- dotnet build CoffeeTalk.sln --no-restore
- dotnet test CoffeeTalk.sln --no-restore
- 58 tests passed
- two independent read-only code-review passes completed