### PR TITLE
Close remaining operational event issues

### DIFF
--- a/CoffeeTalk.Core/Interfaces/IOperationalEventSink.cs
+++ b/CoffeeTalk.Core/Interfaces/IOperationalEventSink.cs
@@ -15,7 +15,10 @@ public sealed record OperationalEvent(
     int? MaxRetries = null,
     int? DelaySeconds = null,
     string? Decision = null,
-    string? Reason = null);
+    string? Reason = null)
+{
+    public Exception? Exception { get; init; }
+}
 
 public interface IOperationalEventSink
 {

--- a/CoffeeTalk.Core/Services/AgentDataExtractor.cs
+++ b/CoffeeTalk.Core/Services/AgentDataExtractor.cs
@@ -89,11 +89,14 @@ Based on the schema description '{_config.SchemaDescription}', extract the data 
         {
             throw;
         }
-        catch (Exception)
+        catch (Exception ex) when (ex is not OutOfMemoryException)
         {
             _eventSink.Publish(new OperationalEvent(
                 OperationalEventKind.OperationFailure,
-                "Data extraction"));
+                "Data extraction")
+            {
+                Exception = ex
+            });
         }
     }
 

--- a/CoffeeTalk.Core/Services/AgentFactChecker.cs
+++ b/CoffeeTalk.Core/Services/AgentFactChecker.cs
@@ -74,11 +74,14 @@ Output Format:
         {
             throw;
         }
-        catch (Exception)
+        catch (Exception ex) when (ex is not OutOfMemoryException)
         {
             _eventSink.Publish(new OperationalEvent(
                 OperationalEventKind.OperationFailure,
-                "Fact check"));
+                "Fact check")
+            {
+                Exception = ex
+            });
         }
     }
 }

--- a/CoffeeTalk.Core/Services/AgentOrchestrator.cs
+++ b/CoffeeTalk.Core/Services/AgentOrchestrator.cs
@@ -163,14 +163,11 @@ Reason: Document complete, all personas contributed, clear consensus reached");
             _speakerCount[selectedPersona.Name]++;
 
             var reasonMatch = Regex.Match(responseText, @"Reason:\s*(.+)", RegexOptions.IgnoreCase);
-            if (reasonMatch.Success)
-            {
-                _eventSink.Publish(new OperationalEvent(
-                    OperationalEventKind.OrchestratorDecision,
-                    "Orchestrator selection",
-                    Decision: selectedPersona.Name,
-                    Reason: LimitReason(reasonMatch.Groups[1].Value)));
-            }
+            _eventSink.Publish(new OperationalEvent(
+                OperationalEventKind.OrchestratorDecision,
+                "Orchestrator selection",
+                Decision: selectedPersona.Name,
+                Reason: reasonMatch.Success ? LimitReason(reasonMatch.Groups[1].Value) : null));
         }
 
         return selectedPersona;

--- a/CoffeeTalk.Gui/Components/Pages/Conversation.razor
+++ b/CoffeeTalk.Gui/Components/Pages/Conversation.razor
@@ -80,7 +80,7 @@
                 <MudAlert Severity="Severity.Info" Dense="true" Class="rounded-0">@UI.StatusMessage</MudAlert>
             }
             <div class="flex-grow-1 overflow-y-auto pa-4" id="chat-container">
-                @foreach (var msg in UI.Messages)
+                @foreach (var msg in UI.GetMessagesSnapshot())
                 {
                     if (msg.IsDivider)
                     {
@@ -269,7 +269,7 @@
                         UI.ConversationTopic,
                         UI.ConversationStartedAt,
                         UI.ConversationParticipants,
-                        UI.Messages);
+                        UI.GetMessagesSnapshot());
                     extension = "html";
                     mimeType = "text/html";
                     break;
@@ -278,7 +278,7 @@
                         UI.ConversationTopic,
                         UI.ConversationStartedAt,
                         UI.ConversationParticipants,
-                        UI.Messages);
+                        UI.GetMessagesSnapshot());
                     extension = "json";
                     mimeType = "application/json";
                     break;
@@ -287,7 +287,7 @@
                         UI.ConversationTopic,
                         UI.ConversationStartedAt,
                         UI.ConversationParticipants,
-                        UI.Messages);
+                        UI.GetMessagesSnapshot());
                     extension = "md";
                     mimeType = "text/markdown";
                     break;
@@ -324,7 +324,7 @@
 
     private int GetMessageCount()
     {
-        return UI.Messages.Count(m => !m.IsDivider && !m.IsSystem);
+        return UI.GetMessagesSnapshot().Count(m => !m.IsDivider && !m.IsSystem);
     }
 
     private string GetElapsedTime(DateTime startedAt)

--- a/CoffeeTalk.Gui/Services/BlazorOperationalEventSink.cs
+++ b/CoffeeTalk.Gui/Services/BlazorOperationalEventSink.cs
@@ -3,17 +3,59 @@ using Microsoft.Extensions.Logging;
 
 namespace CoffeeTalk.Gui.Services;
 
-public sealed class BlazorOperationalEventSink(ILogger<BlazorOperationalEventSink> logger) : IOperationalEventSink
+public sealed class BlazorOperationalEventSink : IOperationalEventSink
 {
+    private readonly ILogger<BlazorOperationalEventSink> _logger;
+    private readonly BlazorUserInterface _ui;
+
+    public BlazorOperationalEventSink(
+        ILogger<BlazorOperationalEventSink> logger,
+        BlazorUserInterface ui)
+    {
+        _logger = logger;
+        _ui = ui;
+    }
+
     public void Publish(OperationalEvent operationalEvent)
     {
-        logger.LogInformation(
-            "Operational event {EventKind} for {Operation}; attempt {Attempt}/{MaxRetries}; decision {Decision}; reason {Reason}",
-            operationalEvent.Kind,
-            operationalEvent.Operation,
-            operationalEvent.Attempt,
-            operationalEvent.MaxRetries,
-            operationalEvent.Decision,
-            operationalEvent.Reason);
+        if (operationalEvent.Exception is not null)
+        {
+            _logger.LogError(
+                operationalEvent.Exception,
+                "Operational event {EventKind} for {Operation}; attempt {Attempt}/{MaxRetries}; decision {Decision}; reason {Reason}",
+                operationalEvent.Kind,
+                operationalEvent.Operation,
+                operationalEvent.Attempt,
+                operationalEvent.MaxRetries,
+                operationalEvent.Decision,
+                operationalEvent.Reason);
+        }
+        else
+        {
+            _logger.LogInformation(
+                "Operational event {EventKind} for {Operation}; attempt {Attempt}/{MaxRetries}; decision {Decision}; reason {Reason}",
+                operationalEvent.Kind,
+                operationalEvent.Operation,
+                operationalEvent.Attempt,
+                operationalEvent.MaxRetries,
+                operationalEvent.Decision,
+                operationalEvent.Reason);
+        }
+
+        var message = operationalEvent.Kind switch
+        {
+            OperationalEventKind.RetryAttempt =>
+                $"Retrying {operationalEvent.Operation} (attempt {operationalEvent.Attempt}/{operationalEvent.MaxRetries}) after {operationalEvent.DelaySeconds}s.",
+            OperationalEventKind.RetryTerminalFailure =>
+                $"{operationalEvent.Operation} failed after {operationalEvent.MaxRetries} retries.",
+            OperationalEventKind.OrchestratorDecision =>
+                $"Orchestrator: {operationalEvent.Decision}" +
+                (string.IsNullOrWhiteSpace(operationalEvent.Reason) ? string.Empty : $" ({operationalEvent.Reason})"),
+            OperationalEventKind.OperationFailure =>
+                $"{operationalEvent.Operation} failed.",
+            _ => throw new ArgumentOutOfRangeException(nameof(operationalEvent), operationalEvent.Kind, "Unknown operational event kind.")
+        };
+
+        _ui.ShowMessageAsync(message).GetAwaiter().GetResult();
     }
 }

--- a/CoffeeTalk.Gui/Services/BlazorUserInterface.cs
+++ b/CoffeeTalk.Gui/Services/BlazorUserInterface.cs
@@ -12,6 +12,11 @@ namespace CoffeeTalk.Gui.Services
         // Chat History
         private readonly object _messagesLock = new();
         public List<ChatMessage> Messages { get; } = new();
+        public IReadOnlyList<ChatMessage> GetMessagesSnapshot()
+        {
+            lock (_messagesLock)
+                return Messages.ToList();
+        }
         public bool StopRequested { get; private set; }
         public string? ConversationTopic { get; private set; }
         public IReadOnlyList<string> ConversationParticipants { get; private set; } = Array.Empty<string>();

--- a/CoffeeTalk.Gui/Services/ConversationSessionService.cs
+++ b/CoffeeTalk.Gui/Services/ConversationSessionService.cs
@@ -132,15 +132,16 @@ public sealed class ConversationSessionService : IConversationSessionService, ID
             {
                 try
                 {
+                    var messages = _ui.GetMessagesSnapshot();
                     _history.Add(new ConversationRecord
                     {
                         Topic = topic,
                         StartedAt = _ui.ConversationStartedAt ?? DateTime.Now,
                         CompletedAt = DateTime.Now,
                         Status = cts.IsCancellationRequested || _ui.StopRequested ? "Stopped" : "Completed",
-                        MessageCount = _ui.Messages.Count,
+                        MessageCount = messages.Count,
                         Personas = _ui.ConversationParticipants.ToList(),
-                        Messages = _ui.Messages.ToList()
+                        Messages = messages.ToList()
                     });
                 }
                 catch (JsonException ex)


### PR DESCRIPTION
## Summary\n- Surface retry, orchestrator, and operation-failure events in the Blazor conversation UI.\n- Publish orchestrator decisions even when the optional reason is omitted.\n- Preserve exception diagnostics while excluding OutOfMemoryException from broad handling.\n- Use lock-protected message snapshots for rendering, export, and history persistence.\n\nCloses #24\nCloses #26\nCloses #30\nCloses #31\nCloses #37\n\n## Validation\n- dotnet test CoffeeTalk.Tests/CoffeeTalk.Tests.csproj\n- dotnet build CoffeeTalk.Gui/CoffeeTalk.Gui.csproj\n- Two independent read-only code-review passes completed on the final diff.