### PR TITLE
Fix Conversation UI change handling

### DIFF
--- a/CoffeeTalk.Gui/Components/Pages/Conversation.razor
+++ b/CoffeeTalk.Gui/Components/Pages/Conversation.razor
@@ -146,15 +146,21 @@
     private string FeedbackMessage = "";
     private int _documentTab;
     private string? _exportFormat;
+    private readonly CancellationTokenSource _scrollCancellation = new();
+    private CancellationToken _scrollCancellationToken;
+    private bool _disposed;
 
     protected override void OnInitialized()
     {
+        _scrollCancellationToken = _scrollCancellation.Token;
         UI.OnChange += OnUiChanged;
     }
 
     public void Dispose()
     {
+        _disposed = true;
         UI.OnChange -= OnUiChanged;
+        _scrollCancellation.Cancel();
     }
 
     private void StopConversation() => Session.Cancel();
@@ -172,23 +178,46 @@
 
     private void OnUiChanged()
     {
-        _ = InvokeAsync(async () =>
+        if (_disposed)
+            return;
+
+        var scrollCancellationToken = _scrollCancellationToken;
+        var renderTask = InvokeAsync(async () =>
         {
+            if (_disposed || scrollCancellationToken.IsCancellationRequested)
+                return;
+
             StateHasChanged();
-            await ScrollToBottomAsync();
+            await ScrollToBottomAsync(scrollCancellationToken);
         });
+        _ = ObserveRenderTaskAsync(renderTask, scrollCancellationToken);
     }
 
-    private void OnChangeScrollToBottom() => _ = ScrollToBottomAsync();
-
-    private async Task ScrollToBottomAsync()
+    private static async Task ObserveRenderTaskAsync(Task renderTask, CancellationToken cancellationToken)
     {
         try
         {
-            await JSRuntime.InvokeVoidAsync("scrollToBottom", "chat-container");
+            await renderTask;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (ObjectDisposedException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (InvalidOperationException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+    }
+
+    private async Task ScrollToBottomAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await JSRuntime.InvokeVoidAsync("scrollToBottom", cancellationToken, "chat-container");
         }
         catch (JSException) { }
-        catch (TaskCanceledException) { }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { }
     }
 
     private async Task SaveChat()

--- a/CoffeeTalk.Tests/ConversationComponentTests.cs
+++ b/CoffeeTalk.Tests/ConversationComponentTests.cs
@@ -3,40 +3,78 @@ using Bunit;
 using CoffeeTalk.Gui.Components;
 using CoffeeTalk.Gui.Services;
 using CoffeeTalk.Services;
+using Microsoft.JSInterop;
 using Microsoft.Extensions.DependencyInjection;
 using MudBlazor.Services;
 using Moq;
+using Bunit.Rendering;
 
 namespace CoffeeTalk.Tests;
 
 public class ConversationComponentTests : TestContext
 {
+    private static (BlazorUserInterface Ui, IRenderedComponent<ContainerFragment> Component) RenderConversation(TestContext context)
+    {
+        context.Services.AddMudServices();
+        context.Services.AddSingleton<ConfigurationService>();
+        context.Services.AddSingleton<AppState>();
+        context.Services.AddSingleton<IApplicationDataPathResolver>(
+            new ApplicationDataPathResolver(Path.Combine(Path.GetTempPath(), "coffeetalk-tests", Guid.NewGuid().ToString("N"))));
+        context.Services.AddSingleton<MudBlazor.ISnackbar, MudBlazor.SnackbarService>();
+
+        var ui = new BlazorUserInterface();
+        context.Services.AddSingleton(ui);
+        context.Services.AddSingleton<IConversationSessionService>(new Mock<IConversationSessionService>().Object);
+
+        var component = context.Render(builder =>
+        {
+            builder.OpenComponent<Conversation>(0);
+            builder.CloseComponent();
+        });
+        return (ui, component);
+    }
+
     [Fact]
     public void Conversation_ShouldRenderMessages()
     {
         // Arrange
-        Services.AddMudServices();
-        Services.AddSingleton<ConfigurationService>();
-        Services.AddSingleton<AppState>();
-        Services.AddSingleton<IApplicationDataPathResolver>(
-            new ApplicationDataPathResolver(Path.Combine(Path.GetTempPath(), "coffeetalk-tests", Guid.NewGuid().ToString("N"))));
-        Services.AddSingleton<MudBlazor.ISnackbar, MudBlazor.SnackbarService>();
-
-        var ui = new BlazorUserInterface();
-        Services.AddSingleton<BlazorUserInterface>(ui);
-        Services.AddSingleton<IConversationSessionService>(new Mock<IConversationSessionService>().Object);
+        var (ui, cut) = RenderConversation(this);
 
         ui.Messages.Add(new ChatMessage { Sender = "Agent", Content = "Hello" });
+        ui.NotifyStateChanged();
 
-        // Act
-        // Trying to use Render instead of RenderComponent to avoid obsolete error
-        var cut = Render(builder => {
-            builder.OpenComponent<Conversation>(0);
-            builder.CloseComponent();
-        });
+        cut.WaitForAssertion(() => Assert.Contains("Hello", cut.Markup));
 
         // Assert
-        Assert.Contains("Hello", cut.Markup);
         Assert.Contains("Agent", cut.Markup);
+    }
+
+    [Fact]
+    public void Conversation_ShouldHandleStateChangesWithOneRendererSafeScroll()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        var (ui, cut) = RenderConversation(this);
+
+        ui.NotifyStateChanged();
+
+        cut.WaitForAssertion(() =>
+            Assert.Single(JSInterop.Invocations.Where(invocation => invocation.Identifier == "scrollToBottom")));
+    }
+
+    [Fact]
+    public void Conversation_ShouldStopHandlingStateChangesAfterDisposal()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        var (ui, cut) = RenderConversation(this);
+        ui.NotifyStateChanged();
+        cut.WaitForAssertion(() =>
+            Assert.Single(JSInterop.Invocations.Where(invocation => invocation.Identifier == "scrollToBottom")));
+        var scrollInvocation = JSInterop.Invocations.Single(invocation => invocation.Identifier == "scrollToBottom");
+
+        cut.FindComponent<Conversation>().Instance.Dispose();
+        ui.NotifyStateChanged();
+
+        Assert.True(scrollInvocation.CancellationToken?.IsCancellationRequested);
+        Assert.Single(JSInterop.Invocations.Where(invocation => invocation.Identifier == "scrollToBottom"));
     }
 }


### PR DESCRIPTION
## Summary\n- consolidate conversation UI updates into one renderer-safe handler\n- cancel scroll work when the component is disposed and observe lifecycle exceptions\n- add focused bUnit regression coverage for rendering, single scroll handling, and disposal cancellation\n\nIssue: #40