### PR TITLE
Notify AppState after persona mutations

### DIFF
--- a/CoffeeTalk.Gui/Components/Pages/Settings.razor
+++ b/CoffeeTalk.Gui/Components/Pages/Settings.razor
@@ -146,23 +146,29 @@
 
         if (!result.Canceled)
         {
-            AppState.Settings.Personas.Add((PersonaConfig)result.Data);
-            AppState.NotifyStateChanged();
+            AppState.AddPersona((PersonaConfig)result.Data);
         }
     }
 
     private async Task EditPersona(PersonaConfig persona)
     {
-        var parameters = new DialogParameters { ["Persona"] = persona };
+        var editablePersona = new PersonaConfig
+        {
+            Name = persona.Name,
+            SystemPrompt = persona.SystemPrompt
+        };
+        var parameters = new DialogParameters { ["Persona"] = editablePersona };
         var dialog = DialogService.Show<PersonaDialog>("Edit Persona", parameters);
-        await dialog.Result;
+        var result = await dialog.Result;
 
-        AppState.NotifyStateChanged();
+        if (!result.Canceled)
+        {
+            AppState.UpdatePersona(persona, (PersonaConfig)result.Data);
+        }
     }
 
     private void DeletePersona(PersonaConfig persona)
     {
-        AppState.Settings.Personas.Remove(persona);
-        AppState.NotifyStateChanged();
+        AppState.RemovePersona(persona);
     }
 }

--- a/CoffeeTalk.Gui/Services/AppState.cs
+++ b/CoffeeTalk.Gui/Services/AppState.cs
@@ -29,5 +29,31 @@ public class AppState
         NotifyStateChanged();
     }
 
+    public void AddPersona(PersonaConfig persona)
+    {
+        Settings.Personas.Add(persona);
+        NotifyStateChanged();
+    }
+
+    public void UpdatePersona(PersonaConfig existingPersona, PersonaConfig updatedPersona)
+    {
+        var index = Settings.Personas.IndexOf(existingPersona);
+        if (index < 0)
+        {
+            return;
+        }
+
+        Settings.Personas[index] = updatedPersona;
+        NotifyStateChanged();
+    }
+
+    public void RemovePersona(PersonaConfig persona)
+    {
+        if (Settings.Personas.Remove(persona))
+        {
+            NotifyStateChanged();
+        }
+    }
+
     public void NotifyStateChanged() => OnChange?.Invoke();
 }

--- a/CoffeeTalk.Tests/AppStateTests.cs
+++ b/CoffeeTalk.Tests/AppStateTests.cs
@@ -1,0 +1,69 @@
+using CoffeeTalk.Gui.Services;
+using CoffeeTalk.Models;
+using CoffeeTalk.Services;
+
+namespace CoffeeTalk.Tests;
+
+public sealed class AppStateTests
+{
+    [Fact]
+    public void PersonaMutations_NotifyExactlyOncePerMutation()
+    {
+        var appState = CreateAppState();
+        var notifications = 0;
+        appState.OnChange += () => notifications++;
+
+        var addedPersona = new PersonaConfig { Name = "Added" };
+        appState.AddPersona(addedPersona);
+        Assert.Equal(1, notifications);
+
+        var updatedPersona = new PersonaConfig { Name = "Updated" };
+        appState.UpdatePersona(addedPersona, updatedPersona);
+        Assert.Equal(2, notifications);
+
+        appState.RemovePersona(updatedPersona);
+        Assert.Equal(3, notifications);
+    }
+
+    [Fact]
+    public void CanceledOrMissingPersonaMutations_DoNotNotify()
+    {
+        var appState = CreateAppState();
+        var notifications = 0;
+        appState.OnChange += () => notifications++;
+
+        appState.UpdatePersona(new PersonaConfig(), new PersonaConfig { Name = "Updated" });
+        appState.RemovePersona(new PersonaConfig());
+
+        Assert.Equal(0, notifications);
+    }
+
+    [Fact]
+    public async Task SaveAndReload_NotifyOncePerOperation()
+    {
+        var appState = CreateAppState();
+        var notifications = 0;
+        appState.OnChange += () => notifications++;
+
+        appState.AddPersona(new PersonaConfig
+        {
+            Name = "Persisted",
+            SystemPrompt = "A persisted persona"
+        });
+        await appState.SaveSettingsAsync();
+        Assert.Equal(2, notifications);
+
+        appState.LoadSettings();
+        Assert.Equal(3, notifications);
+        var persona = Assert.Single(appState.Settings.Personas);
+        Assert.Equal("Persisted", persona.Name);
+        Assert.Equal("A persisted persona", persona.SystemPrompt);
+    }
+
+    private static AppState CreateAppState()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "coffeetalk-tests", Guid.NewGuid().ToString("N"));
+        var resolver = new ApplicationDataPathResolver(root);
+        return new AppState(new ConfigurationService(resolver));
+    }
+}


### PR DESCRIPTION
## Summary\n- centralize persona add, edit, and delete mutations in AppState\n- notify observers exactly once for successful mutations\n- prevent canceled persona edits from mutating shared state\n- add focused notification and save/reload tests\n\n## Tests\n- dotnet test CoffeeTalk.Tests/CoffeeTalk.Tests.csproj --filter 'FullyQualifiedName~AppStateTests'\n- dotnet test CoffeeTalk.sln