### PR TITLE
Add versioned conversation persistence

### DIFF
--- a/CoffeeTalk.Core/Models/ConversationState.cs
+++ b/CoffeeTalk.Core/Models/ConversationState.cs
@@ -1,0 +1,37 @@
+namespace CoffeeTalk.Models;
+
+public static class ConversationStateSchema
+{
+    public const int CurrentVersion = 1;
+}
+
+public sealed class ConversationState
+{
+    public int SchemaVersion { get; set; } = ConversationStateSchema.CurrentVersion;
+    public string Id { get; set; } = Guid.NewGuid().ToString("N");
+    public string Topic { get; set; } = string.Empty;
+    public string DocumentContent { get; set; } = string.Empty;
+    public List<ConversationMessage> Messages { get; set; } = new();
+    public List<ConversationParticipant> Participants { get; set; } = new();
+    public DateTimeOffset StartedAt { get; set; }
+    public DateTimeOffset? CompletedAt { get; set; }
+    public string Status { get; set; } = "Completed";
+    public Dictionary<string, string> Metadata { get; set; } = new(StringComparer.Ordinal);
+}
+
+public sealed class ConversationMessage
+{
+    public string Sender { get; set; } = string.Empty;
+    public string Content { get; set; } = string.Empty;
+    public bool IsSystem { get; set; }
+    public bool IsError { get; set; }
+    public bool IsDivider { get; set; }
+    public DateTimeOffset Timestamp { get; set; }
+}
+
+public sealed class ConversationParticipant
+{
+    public string Name { get; set; } = string.Empty;
+    public string? Role { get; set; }
+    public Dictionary<string, string> Metadata { get; set; } = new(StringComparer.Ordinal);
+}

--- a/CoffeeTalk.Core/Services/ConversationPersistenceService.cs
+++ b/CoffeeTalk.Core/Services/ConversationPersistenceService.cs
@@ -1,0 +1,123 @@
+using System.Text.Json;
+using CoffeeTalk.Models;
+
+namespace CoffeeTalk.Services;
+
+public interface IConversationPersistenceService
+{
+    Task<string> SaveAsync(ConversationState state, CancellationToken cancellationToken = default);
+    Task<ConversationState> ResumeAsync(string id, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<ConversationState>> ListAsync(CancellationToken cancellationToken = default);
+    Task DeleteAsync(string id, CancellationToken cancellationToken = default);
+}
+
+public class ConversationStateCorruptException : Exception
+{
+    public ConversationStateCorruptException(string message, Exception? inner = null) : base(message, inner) { }
+}
+
+public sealed class ConversationStateVersionException : ConversationStateCorruptException
+{
+    public ConversationStateVersionException(int version)
+        : base($"Conversation state schema version {version} is not supported.") { }
+}
+
+public sealed class ConversationPersistenceService : IConversationPersistenceService
+{
+    private const string DirectoryName = "conversations";
+    private readonly IApplicationDataPathResolver _paths;
+    private readonly JsonSerializerOptions _json = new(JsonSerializerDefaults.Web) { WriteIndented = true };
+
+    public ConversationPersistenceService(IApplicationDataPathResolver? paths = null)
+        => _paths = paths ?? new ApplicationDataPathResolver();
+
+    public async Task<string> SaveAsync(ConversationState state, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+        var id = NormalizeId(state.Id);
+        state.Id = id;
+        state.SchemaVersion = ConversationStateSchema.CurrentVersion;
+        var path = PathFor(id);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        var temporary = path + "." + Guid.NewGuid().ToString("N") + ".tmp";
+        try
+        {
+            await using (var stream = new FileStream(temporary, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+                await JsonSerializer.SerializeAsync(stream, state, _json, cancellationToken);
+            File.Move(temporary, path, true);
+            return id;
+        }
+        finally
+        {
+            if (File.Exists(temporary))
+                File.Delete(temporary);
+        }
+    }
+
+    public async Task<ConversationState> ResumeAsync(string id, CancellationToken cancellationToken = default)
+    {
+        var path = PathFor(NormalizeId(id));
+        if (!File.Exists(path))
+            throw new FileNotFoundException("Conversation state was not found.", path);
+        try
+        {
+            await using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+            var state = await JsonSerializer.DeserializeAsync<ConversationState>(stream, _json, cancellationToken)
+                ?? throw new ConversationStateCorruptException("Conversation state is empty.");
+            if (state.SchemaVersion != ConversationStateSchema.CurrentVersion)
+                throw new ConversationStateVersionException(state.SchemaVersion);
+            if (state.Messages is null || state.Participants is null || state.Metadata is null ||
+                string.IsNullOrWhiteSpace(state.Topic))
+                throw new ConversationStateCorruptException("Conversation state is missing required fields.");
+            state.Id = NormalizeId(state.Id);
+            if (!state.Id.Equals(id, StringComparison.Ordinal))
+                throw new ConversationStateCorruptException("Conversation state identifier does not match its file.");
+            return state;
+        }
+        catch (ConversationStateCorruptException) { throw; }
+        catch (JsonException ex) { throw new ConversationStateCorruptException("Conversation state JSON is invalid.", ex); }
+        catch (NotSupportedException ex) { throw new ConversationStateCorruptException("Conversation state JSON is invalid.", ex); }
+    }
+
+    public async Task<IReadOnlyList<ConversationState>> ListAsync(CancellationToken cancellationToken = default)
+    {
+        var directory = _paths.ResolveDataPath(DirectoryName, "conversation.json");
+        if (!Directory.Exists(directory))
+            return Array.Empty<ConversationState>();
+        var results = new List<ConversationState>();
+        foreach (var path in Directory.EnumerateFiles(directory, "*.json"))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                results.Add(await ResumeAsync(Path.GetFileNameWithoutExtension(path), cancellationToken));
+            }
+            catch (ConversationStateCorruptException)
+            {
+                // A damaged entry must not hide healthy conversations from list consumers.
+            }
+        }
+        return results.OrderByDescending(x => x.StartedAt).ToList();
+    }
+
+    public Task DeleteAsync(string id, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var path = PathFor(NormalizeId(id));
+        if (!File.Exists(path))
+            throw new FileNotFoundException("Conversation state was not found.", path);
+        File.Delete(path);
+        return Task.CompletedTask;
+    }
+
+    private string PathFor(string id) =>
+        _paths.ResolveDataPath($"{DirectoryName}/{id}.json", "conversation.json");
+
+    private static string NormalizeId(string id)
+    {
+        if (string.IsNullOrWhiteSpace(id) || id.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0 ||
+            id.Contains('/') || id.Contains('\\') || id is "." or "..")
+            throw new UnauthorizedAccessException("Conversation identifiers must be safe file names.");
+        return id;
+    }
+}

--- a/CoffeeTalk.Gui/Services/BlazorUserInterface.cs
+++ b/CoffeeTalk.Gui/Services/BlazorUserInterface.cs
@@ -225,8 +225,8 @@ namespace CoffeeTalk.Gui.Services
             StatusMessage = null;
             IsBusy = false;
             CurrentThinkingPersona = null;
-            DocumentContent = "";
-            DocumentMarkdown = "";
+            DocumentContent = record.DocumentContent;
+            DocumentMarkdown = record.DocumentContent;
             NotifyStateChanged();
         }
 

--- a/CoffeeTalk.Gui/Services/ConversationHistoryService.cs
+++ b/CoffeeTalk.Gui/Services/ConversationHistoryService.cs
@@ -1,80 +1,105 @@
 using System.Text.Json;
+using CoffeeTalk.Models;
 using CoffeeTalk.Services;
 
 namespace CoffeeTalk.Gui.Services;
 
 public sealed class ConversationHistoryService
 {
-    private readonly string _historyPath;
-    private readonly object _sync = new();
-    private readonly List<ConversationRecord> _records;
+    private readonly ConversationPersistenceService _persistence;
+    private readonly IApplicationDataPathResolver _paths;
 
     public ConversationHistoryService(IApplicationDataPathResolver? paths = null)
     {
-        var resolver = paths ?? new ApplicationDataPathResolver();
-        _historyPath = resolver.ResolveDataPath("conversation-history.json", "conversation-history.json");
-        _records = Load();
+        _paths = paths ?? new ApplicationDataPathResolver();
+        _persistence = new ConversationPersistenceService(_paths);
     }
 
     public IReadOnlyList<ConversationRecord> Recent(int count = 10)
+        => RecentAsync(count).GetAwaiter().GetResult();
+
+    public async Task<IReadOnlyList<ConversationRecord>> RecentAsync(int count = 10, CancellationToken cancellationToken = default)
     {
-        lock (_sync)
-        {
-            return _records
-                .OrderByDescending(record => record.StartedAt)
-                .Take(count)
-                .Select(Clone)
-                .ToList();
-        }
+        var states = await _persistence.ListAsync(cancellationToken);
+        if (states.Count == 0)
+            states = await MigrateLegacyAsync(cancellationToken);
+        return states.Take(count).Select(ToRecord).ToList();
     }
 
-    public void Add(ConversationRecord record)
-    {
-        lock (_sync)
-        {
-            _records.Add(Clone(record));
-            Directory.CreateDirectory(Path.GetDirectoryName(_historyPath)!);
-            File.WriteAllText(_historyPath, JsonSerializer.Serialize(_records, new JsonSerializerOptions { WriteIndented = true }));
-        }
-    }
+    public Task<string> SaveAsync(ConversationRecord record, CancellationToken cancellationToken = default)
+        => _persistence.SaveAsync(ToState(record), cancellationToken);
 
-    private List<ConversationRecord> Load()
+    public Task<ConversationRecord> ResumeAsync(string id, CancellationToken cancellationToken = default)
+        => ResumeCoreAsync(id, cancellationToken);
+
+    public Task DeleteAsync(string id, CancellationToken cancellationToken = default)
+        => _persistence.DeleteAsync(id, cancellationToken);
+
+    public string Add(ConversationRecord record)
+        => SaveAsync(record).GetAwaiter().GetResult();
+
+    private async Task<ConversationRecord> ResumeCoreAsync(string id, CancellationToken cancellationToken)
+        => ToRecord(await _persistence.ResumeAsync(id, cancellationToken));
+
+    private async Task<IReadOnlyList<ConversationState>> MigrateLegacyAsync(CancellationToken cancellationToken)
     {
+        var path = _paths.ResolveDataPath("conversation-history.json", "conversation-history.json");
+        if (!File.Exists(path))
+            return Array.Empty<ConversationState>();
+
         try
         {
-            if (!File.Exists(_historyPath))
+            var records = JsonSerializer.Deserialize<List<ConversationRecord>>(
+                await File.ReadAllTextAsync(path, cancellationToken),
+                new JsonSerializerOptions(JsonSerializerDefaults.Web)) ?? new();
+            var migrated = new List<ConversationState>();
+            foreach (var record in records)
             {
-                return new();
+                cancellationToken.ThrowIfCancellationRequested();
+                var state = ToState(record);
+                await _persistence.SaveAsync(state, cancellationToken);
+                migrated.Add(state);
             }
-
-            return JsonSerializer.Deserialize<List<ConversationRecord>>(File.ReadAllText(_historyPath)) ?? new();
+            return migrated;
         }
-        catch (JsonException)
+        catch (JsonException ex)
         {
-            return new();
-        }
-        catch (IOException)
-        {
-            return new();
+            throw new ConversationStateCorruptException("Legacy conversation history JSON is invalid.", ex);
         }
     }
 
-    private static ConversationRecord Clone(ConversationRecord record) => new()
+    private static ConversationState ToState(ConversationRecord record) => new()
     {
+        Id = record.Id,
         Topic = record.Topic,
-        StartedAt = record.StartedAt,
-        CompletedAt = record.CompletedAt,
+        StartedAt = new DateTimeOffset(record.StartedAt),
+        CompletedAt = record.CompletedAt.HasValue ? new DateTimeOffset(record.CompletedAt.Value) : null,
         Status = record.Status,
-        MessageCount = record.MessageCount,
-        Personas = record.Personas.ToList(),
-        Messages = record.Messages.Select(message => new ChatMessage
+        DocumentContent = record.DocumentContent,
+        Participants = record.Personas.Select(name => new ConversationParticipant { Name = name }).ToList(),
+        Messages = record.Messages.Select(message => new ConversationMessage
         {
-            Sender = message.Sender,
-            Content = message.Content,
-            IsSystem = message.IsSystem,
-            IsError = message.IsError,
-            IsDivider = message.IsDivider,
-            Timestamp = message.Timestamp
+            Sender = message.Sender, Content = message.Content, IsSystem = message.IsSystem,
+            IsError = message.IsError, IsDivider = message.IsDivider, Timestamp = new DateTimeOffset(message.Timestamp)
+        }).ToList(),
+        Metadata = new Dictionary<string, string>(record.Metadata, StringComparer.Ordinal)
+    };
+
+    private static ConversationRecord ToRecord(ConversationState state) => new()
+    {
+        Id = state.Id,
+        Topic = state.Topic,
+        StartedAt = state.StartedAt.LocalDateTime,
+        CompletedAt = state.CompletedAt?.LocalDateTime,
+        Status = state.Status,
+        MessageCount = state.Messages.Count(message => !message.IsSystem && !message.IsDivider),
+        Personas = state.Participants.Select(participant => participant.Name).ToList(),
+        DocumentContent = state.DocumentContent,
+        Metadata = new Dictionary<string, string>(state.Metadata, StringComparer.Ordinal),
+        Messages = state.Messages.Select(message => new ChatMessage
+        {
+            Sender = message.Sender, Content = message.Content, IsSystem = message.IsSystem,
+            IsError = message.IsError, IsDivider = message.IsDivider, Timestamp = message.Timestamp.LocalDateTime
         }).ToList()
     };
 }

--- a/CoffeeTalk.Gui/Services/ConversationRecord.cs
+++ b/CoffeeTalk.Gui/Services/ConversationRecord.cs
@@ -2,6 +2,7 @@ namespace CoffeeTalk.Gui.Services;
 
 public sealed class ConversationRecord
 {
+    public string Id { get; set; } = Guid.NewGuid().ToString("N");
     public string Topic { get; set; } = string.Empty;
     public DateTime StartedAt { get; set; }
     public DateTime? CompletedAt { get; set; }
@@ -9,4 +10,6 @@ public sealed class ConversationRecord
     public int MessageCount { get; set; }
     public List<string> Personas { get; set; } = new();
     public List<ChatMessage> Messages { get; set; } = new();
+    public string DocumentContent { get; set; } = string.Empty;
+    public Dictionary<string, string> Metadata { get; set; } = new(StringComparer.Ordinal);
 }

--- a/CoffeeTalk.Gui/Services/ConversationSessionService.cs
+++ b/CoffeeTalk.Gui/Services/ConversationSessionService.cs
@@ -1,7 +1,6 @@
 using CoffeeTalk.Models;
 using CoffeeTalk.Services;
 using Microsoft.Extensions.Logging;
-using System.Text.Json;
 
 namespace CoffeeTalk.Gui.Services;
 
@@ -141,12 +140,9 @@ public sealed class ConversationSessionService : IConversationSessionService, ID
                         Status = cts.IsCancellationRequested || _ui.StopRequested ? "Stopped" : "Completed",
                         MessageCount = messages.Count,
                         Personas = _ui.ConversationParticipants.ToList(),
-                        Messages = messages.ToList()
+                        Messages = messages.ToList(),
+                        DocumentContent = _ui.DocumentMarkdown
                     });
-                }
-                catch (JsonException ex)
-                {
-                    _logger.LogError(ex, "Failed to serialize conversation history for {Topic}", topic);
                 }
                 catch (IOException ex)
                 {

--- a/CoffeeTalk.Tests/ConversationPersistenceServiceTests.cs
+++ b/CoffeeTalk.Tests/ConversationPersistenceServiceTests.cs
@@ -1,0 +1,75 @@
+using System.Text.Json;
+using CoffeeTalk.Models;
+using CoffeeTalk.Services;
+
+namespace CoffeeTalk.Tests;
+
+public sealed class ConversationPersistenceServiceTests
+{
+    [Fact]
+    public async Task SaveResumeRoundTripPreservesState()
+    {
+        var root = NewRoot();
+        var service = new ConversationPersistenceService(new ApplicationDataPathResolver(root));
+        var state = new ConversationState
+        {
+            Id = "round-trip",
+            Topic = "Planning",
+            DocumentContent = "# Notes",
+            StartedAt = DateTimeOffset.UtcNow,
+            Participants = new() { new() { Name = "Engineer", Role = "builder" } },
+            Messages = new() { new() { Sender = "Engineer", Content = "Ready" } },
+            Metadata = new() { ["source"] = "test" }
+        };
+
+        await service.SaveAsync(state);
+        var restored = await service.ResumeAsync("round-trip");
+
+        Assert.Equal(state.Topic, restored.Topic);
+        Assert.Equal(state.DocumentContent, restored.DocumentContent);
+        Assert.Equal("Engineer", restored.Participants[0].Name);
+        Assert.Equal("test", restored.Metadata["source"]);
+    }
+
+    [Fact]
+    public async Task ResumeRejectsVersionMismatchAndCorruption()
+    {
+        var root = NewRoot();
+        var resolver = new ApplicationDataPathResolver(root);
+        var service = new ConversationPersistenceService(resolver);
+        await service.SaveAsync(new ConversationState { Id = "versioned" });
+        var path = resolver.ResolveDataPath("conversations/versioned.json", "conversation.json");
+        var json = await File.ReadAllTextAsync(path);
+        var node = JsonSerializer.Deserialize<Dictionary<string, object>>(json)!;
+        node["schemaVersion"] = 99;
+        await File.WriteAllTextAsync(path, JsonSerializer.Serialize(node));
+        await Assert.ThrowsAsync<ConversationStateVersionException>(() => service.ResumeAsync("versioned"));
+        await File.WriteAllTextAsync(path, "{");
+        await Assert.ThrowsAsync<ConversationStateCorruptException>(() => service.ResumeAsync("versioned"));
+    }
+
+    [Fact]
+    public async Task PathsAndCancellationAreEnforced()
+    {
+        var service = new ConversationPersistenceService(new ApplicationDataPathResolver(NewRoot()));
+        await Assert.ThrowsAsync<UnauthorizedAccessException>(() => service.ResumeAsync("../escape"));
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => service.SaveAsync(new ConversationState(), cancellation.Token));
+    }
+
+    [Fact]
+    public async Task ListAndDeleteManageSavedStates()
+    {
+        var service = new ConversationPersistenceService(new ApplicationDataPathResolver(NewRoot()));
+        await service.SaveAsync(new ConversationState { Id = "one", Topic = "One" });
+        await service.SaveAsync(new ConversationState { Id = "two", Topic = "Two" });
+
+        Assert.Equal(2, (await service.ListAsync()).Count);
+        await service.DeleteAsync("one");
+        Assert.Single(await service.ListAsync());
+        await Assert.ThrowsAsync<FileNotFoundException>(() => service.ResumeAsync("one"));
+    }
+
+    private static string NewRoot() => Path.Combine(Path.GetTempPath(), "coffeetalk-tests", Guid.NewGuid().ToString("N"));
+}

--- a/CoffeeTalk/Program.cs
+++ b/CoffeeTalk/Program.cs
@@ -14,6 +14,10 @@ class Program
         try
         {
             var dataPaths = new ApplicationDataPathResolver();
+            var persistence = new ConversationPersistenceService(dataPaths);
+            if (await HandleHistoryCommandAsync(args, persistence))
+                return;
+
             var configService = new ConfigurationService(dataPaths);
             var settings = configService.LoadConfiguration();
             settings = await ConfigurationHelper.ValidateAndConfigureAsync(configService, settings);
@@ -42,6 +46,26 @@ class Program
 
             AnsiConsole.MarkupLine($"[bold]Personas:[/] {string.Join(", ", pipeline.Personas.Select(p => Markup.Escape(p.Name)))}\n");
             await pipeline.CreateConversation(ui).StartConversationAsync(topic);
+            if (args.Contains("--save", StringComparer.OrdinalIgnoreCase))
+            {
+                var consoleUi = (ConsoleUserInterface)ui;
+                var saveId = GetOption(args, "--save") ?? Guid.NewGuid().ToString("N");
+                await persistence.SaveAsync(new ConversationState
+                {
+                    Id = saveId,
+                    Topic = consoleUi.ConversationTopic ?? topic,
+                    Participants = consoleUi.ConversationParticipants.Select(name => new ConversationParticipant { Name = name }).ToList(),
+                    StartedAt = consoleUi.ConversationStartedAt ?? DateTimeOffset.Now,
+                    CompletedAt = DateTimeOffset.Now,
+                    DocumentContent = consoleUi.DocumentContent,
+                    Messages = consoleUi.Messages.Select(message => new ConversationMessage
+                    {
+                        Sender = message.Sender, Content = message.Content, IsSystem = message.IsSystem,
+                        IsError = message.IsError, IsDivider = message.IsDivider, Timestamp = DateTimeOffset.Now
+                    }).ToList()
+                });
+                AnsiConsole.MarkupLine($"[green]Saved conversation {Markup.Escape(saveId)}[/]");
+            }
             AnsiConsole.MarkupLine("\n[bold green]Thank you for using CoffeeTalk! ☕[/]");
         }
         catch (OperationCanceledException ex)
@@ -55,5 +79,45 @@ class Program
             AnsiConsole.MarkupLine("\n[bold red]Please check your configuration and try again.[/]");
             Environment.Exit(1);
         }
+    }
+
+    private static async Task<bool> HandleHistoryCommandAsync(string[] args, ConversationPersistenceService persistence)
+    {
+        if (args.Contains("--list", StringComparer.OrdinalIgnoreCase))
+        {
+            foreach (var state in await persistence.ListAsync())
+                AnsiConsole.MarkupLine($"{Markup.Escape(state.Id)}  {Markup.Escape(state.Topic)}  {state.Status}");
+            return true;
+        }
+
+        var deleteId = GetOption(args, "--delete");
+        if (deleteId is not null)
+        {
+            await persistence.DeleteAsync(deleteId);
+            AnsiConsole.MarkupLine($"[green]Deleted conversation {Markup.Escape(deleteId)}[/]");
+            return true;
+        }
+
+        var resumeId = GetOption(args, "--resume");
+        if (resumeId is not null)
+        {
+            var state = await persistence.ResumeAsync(resumeId);
+            AnsiConsole.MarkupLine($"[bold]Topic:[/] {Markup.Escape(state.Topic)}");
+            AnsiConsole.MarkupLine($"[bold]Status:[/] {Markup.Escape(state.Status)}");
+            AnsiConsole.WriteLine(state.DocumentContent);
+            foreach (var message in state.Messages)
+                AnsiConsole.MarkupLine($"[bold]{Markup.Escape(message.Sender)}:[/] {Markup.Escape(message.Content)}");
+            return true;
+        }
+
+        return false;
+    }
+
+    private static string? GetOption(string[] args, string option)
+    {
+        var index = Array.FindIndex(args, value => value.Equals(option, StringComparison.OrdinalIgnoreCase));
+        return index >= 0 && index + 1 < args.Length && !args[index + 1].StartsWith("-", StringComparison.Ordinal)
+            ? args[index + 1]
+            : null;
     }
 }

--- a/CoffeeTalk/Services/ConsoleUserInterface.cs
+++ b/CoffeeTalk/Services/ConsoleUserInterface.cs
@@ -9,21 +9,29 @@ namespace CoffeeTalk.Services
     public class ConsoleUserInterface : IUserInterface
     {
         public bool StopRequested => false;
+        public string? ConversationTopic { get; private set; }
+        public IReadOnlyList<string> ConversationParticipants { get; private set; } = Array.Empty<string>();
+        public DateTimeOffset? ConversationStartedAt { get; private set; }
+        public string DocumentContent { get; private set; } = string.Empty;
+        public List<ConsoleMessage> Messages { get; } = new();
 
         public Task ShowMessageAsync(string message)
         {
+            Messages.Add(new ConsoleMessage("System", message, true, false, false));
             AnsiConsole.MarkupLine(message);
             return Task.CompletedTask;
         }
 
         public Task ShowErrorAsync(string message)
         {
+            Messages.Add(new ConsoleMessage("Error", message, false, true, false));
             AnsiConsole.MarkupLine($"[red]{message}[/]");
             return Task.CompletedTask;
         }
 
         public Task ShowAgentResponseAsync(string agentName, string response)
         {
+            Messages.Add(new ConsoleMessage(agentName, response, false, false, false));
             var panel = new Panel(new Text(response))
                 .Header($"[bold]{Markup.Escape(agentName)}[/]")
                 .Border(BoxBorder.Rounded);
@@ -34,6 +42,7 @@ namespace CoffeeTalk.Services
 
         public Task ShowDocumentPreviewAsync(string content)
         {
+            DocumentContent = content;
             var panel = new Panel(new Text(content))
                 .Header("[bold cyan]Document State[/]")
                 .Border(BoxBorder.Rounded)
@@ -104,6 +113,9 @@ namespace CoffeeTalk.Services
 
         public Task ShowConversationHeaderAsync(string topic, IReadOnlyCollection<string> participants, string mode, bool interactive)
         {
+            ConversationTopic = topic;
+            ConversationParticipants = participants.ToList();
+            ConversationStartedAt = DateTimeOffset.Now;
             AnsiConsole.MarkupLine($"\n[bold]🎯 Topic:[/] [cyan]{Markup.Escape(topic)}[/]\n");
             AnsiConsole.MarkupLine($"[bold]Participants:[/] {string.Join(", ", participants.Select(p => Markup.Escape(p)))}\n");
             AnsiConsole.MarkupLine($"[bold]Mode:[/] {mode}\n");
@@ -128,4 +140,6 @@ namespace CoffeeTalk.Services
             return Task.CompletedTask;
         }
     }
+
+    public sealed record ConsoleMessage(string Sender, string Content, bool IsSystem, bool IsError, bool IsDivider);
 }


### PR DESCRIPTION
Implements issue #45 with versioned conversation-state DTOs and safe persistence, GUI history/resume integration, CLI --save/--resume/--list/--delete operations, legacy history migration, explicit corruption/version handling, cancellation, and focused tests. Excludes persona-tool and PDF-export surfaces.