### PR TITLE
Add persona-specific tool specialization

### DIFF
--- a/CoffeeTalk.Core/Models/PersonaConfig.cs
+++ b/CoffeeTalk.Core/Models/PersonaConfig.cs
@@ -4,4 +4,5 @@ public class PersonaConfig
 {
     public string Name { get; set; } = string.Empty;
     public string SystemPrompt { get; set; } = string.Empty;
+    public List<string>? AllowedTools { get; set; }
 }

--- a/CoffeeTalk.Core/Services/AgentOrchestrator.cs
+++ b/CoffeeTalk.Core/Services/AgentOrchestrator.cs
@@ -55,7 +55,12 @@ public partial class AgentOrchestrator
             
             // Extract key characteristics from system prompt
             var description = ExtractPersonaDescription(persona.SystemPrompt);
-            sb.AppendLine(description);
+            sb.Append(description);
+            sb.Append(" (Capabilities: ");
+            sb.Append(persona.EffectiveToolNames.Count == 0
+                ? "no document tools"
+                : string.Join(", ", persona.EffectiveToolNames));
+            sb.AppendLine(")");
         }
         sb.AppendLine();
 
@@ -209,7 +214,7 @@ Reason: Document complete, all personas contributed, clear consensus reached");
         sb.AppendLine("Available personas:");
         foreach (var persona in _availablePersonas)
         {
-            sb.AppendLine($"- {persona.Name}");
+            sb.AppendLine($"- {persona.Name} (Capabilities: {(persona.EffectiveToolNames.Count == 0 ? "no document tools" : string.Join(", ", persona.EffectiveToolNames))})");
         }
         sb.AppendLine();
 

--- a/CoffeeTalk.Core/Services/AgentPersona.cs
+++ b/CoffeeTalk.Core/Services/AgentPersona.cs
@@ -19,6 +19,27 @@ public class AgentPersona
 
     public string Name => _config.Name;
     public string SystemPrompt => _config.SystemPrompt;
+    public IReadOnlyList<string> EffectiveToolNames { get; }
+
+    public AgentPersona(
+        AIAgent agent,
+        PersonaConfig config,
+        CollaborativeMarkdownDocument doc,
+        RateLimiter? rateLimiter,
+        int maxTurns,
+        int agentCount,
+        IRetryService retryService,
+        IReadOnlyCollection<string>? effectiveToolNames = null)
+    {
+        _agent = agent;
+        _config = config;
+        _doc = doc;
+        _rateLimiter = rateLimiter;
+        _maxTurns = maxTurns;
+        _agentCount = agentCount;
+        _retryService = retryService;
+        EffectiveToolNames = effectiveToolNames?.ToList() ?? [];
+    }
 
     public AgentPersona(
         AIAgent agent,
@@ -28,14 +49,8 @@ public class AgentPersona
         int maxTurns,
         int agentCount,
         IRetryService retryService)
+        : this(agent, config, doc, rateLimiter, maxTurns, agentCount, retryService, null)
     {
-        _agent = agent;
-        _config = config;
-        _doc = doc;
-        _rateLimiter = rateLimiter;
-        _maxTurns = maxTurns;
-        _agentCount = agentCount;
-        _retryService = retryService;
     }
 
     public AgentPersona(

--- a/CoffeeTalk.Core/Services/ConversationPipelineBuilder.cs
+++ b/CoffeeTalk.Core/Services/ConversationPipelineBuilder.cs
@@ -63,6 +63,7 @@ public sealed class ConversationPipeline
 public sealed class ConversationPipelineBuilder
 {
     private const string DevilsAdvocateName = "DevilsAdvocate";
+    private const string FallbackJsonToolName = "ExecuteJsonTool";
     private readonly IApplicationDataPathResolver _dataPaths;
     private readonly IOperationalEventSink _eventSink;
     private readonly IConversationAgentFactory _agentFactory;
@@ -111,6 +112,7 @@ public sealed class ConversationPipelineBuilder
                 notify);
         }
 
+        ValidateAllowedTools(personaConfigs, tools);
         var personas = CreatePersonas(settings, personaConfigs, sharedDocument, rateLimiter, retryService, tools);
 
         if (settings.DevilsAdvocate &&
@@ -275,7 +277,8 @@ public sealed class ConversationPipelineBuilder
         AIFunction[] tools,
         int? totalPersonaCount = null)
     {
-        var agent = _agentFactory.Create(settings.LlmProvider, config.Name, config.SystemPrompt, tools);
+        var personaTools = FilterTools(config, tools);
+        var agent = _agentFactory.Create(settings.LlmProvider, config.Name, config.SystemPrompt, personaTools);
         return new AgentPersona(
             agent,
             config,
@@ -283,6 +286,45 @@ public sealed class ConversationPipelineBuilder
             rateLimiter,
             settings.MaxConversationTurns,
             totalPersonaCount ?? agentCount,
-            retryService);
+            retryService,
+            personaTools.Select(tool => tool.Name).ToList());
+    }
+
+    private static void ValidateAllowedTools(IEnumerable<PersonaConfig> configs, AIFunction[] tools)
+    {
+        var availableNames = tools
+            .Select(tool => tool.Name)
+            .Where(name => !name.Equals(FallbackJsonToolName, StringComparison.OrdinalIgnoreCase))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var config in configs)
+        {
+            if (config.AllowedTools is null)
+                continue;
+
+            var unknown = config.AllowedTools
+                .Where(name => !availableNames.Contains(name))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+            if (unknown.Count > 0)
+            {
+                throw new ArgumentException(
+                    $"Persona '{config.Name}' contains unknown or unsupported tools: {string.Join(", ", unknown)}.",
+                    nameof(configs));
+            }
+        }
+    }
+
+    private static AIFunction[] FilterTools(PersonaConfig config, AIFunction[] tools)
+    {
+        if (config.AllowedTools is null)
+            return tools;
+
+        var allowed = config.AllowedTools.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        return tools
+            .Where(tool =>
+                !tool.Name.Equals(FallbackJsonToolName, StringComparison.OrdinalIgnoreCase) &&
+                allowed.Contains(tool.Name))
+            .ToArray();
     }
 }

--- a/CoffeeTalk.Tests/AgentOrchestratorTests.cs
+++ b/CoffeeTalk.Tests/AgentOrchestratorTests.cs
@@ -16,4 +16,24 @@ public sealed class AgentOrchestratorTests
         Assert.Contains("CONCLUDE", prompt);
         Assert.Contains("Line 1", prompt);
     }
+
+    [Fact]
+    public void BuildSystemPrompt_ListsPersonaCapabilities()
+    {
+        var persona = new AgentPersona(
+            new TestAIAgent(() => throw new InvalidOperationException()),
+            new PersonaConfig { Name = "Architect", SystemPrompt = "You are Architect." },
+            new CollaborativeMarkdownDocument(),
+            null,
+            maxTurns: 2,
+            agentCount: 1,
+            retryService: new RetryService(null),
+            effectiveToolNames: ["AddHeading"]);
+
+        var prompt = AgentOrchestrator.BuildSystemPrompt(
+            new OrchestratorConfig { BaseSystemPrompt = "Base instructions" },
+            [persona]);
+
+        Assert.Contains("Capabilities: AddHeading", prompt);
+    }
 }

--- a/CoffeeTalk.Tests/ConversationPipelineBuilderTests.cs
+++ b/CoffeeTalk.Tests/ConversationPipelineBuilderTests.cs
@@ -56,6 +56,49 @@ public sealed class ConversationPipelineBuilderTests
         Assert.Equal(cli.ToolsConfig.RequireToolsVerification, gui.ToolsConfig.RequireToolsVerification);
     }
 
+    [Fact]
+    public async Task BuildAsync_FiltersPersonaToolsByAllowedTools()
+    {
+        var factory = new RecordingAgentFactory();
+        var settings = CreateSettings();
+        settings.Personas[0].AllowedTools = ["AddHeading", "InsertAfterHeading"];
+
+        var pipeline = await CreateBuilder(factory).BuildAsync(settings, "topic");
+
+        var tools = factory.Created.Single(agent => agent.Name == "Analyst").Tools!;
+        Assert.Equal(
+            new[] { "AddHeading", "InsertAfterHeading" },
+            tools.Select(tool => tool.Name));
+        Assert.Equal(
+            new[] { "AddHeading", "InsertAfterHeading" },
+            pipeline.Personas.Single(persona => persona.Name == "Analyst").EffectiveToolNames);
+    }
+
+    [Fact]
+    public async Task BuildAsync_RejectsUnknownPersonaTool()
+    {
+        var settings = CreateSettings();
+        settings.Personas[0].AllowedTools = ["NotARealTool"];
+
+        var exception = await Assert.ThrowsAsync<ArgumentException>(
+            () => CreateBuilder(new RecordingAgentFactory()).BuildAsync(settings, "topic"));
+
+        Assert.Contains("NotARealTool", exception.Message);
+    }
+
+    [Fact]
+    public async Task BuildAsync_DoesNotExposeFallbackDispatcherToRestrictedPersona()
+    {
+        var factory = new RecordingAgentFactory();
+        var settings = CreateSettings();
+        settings.Personas[0].AllowedTools = ["SetTitle"];
+
+        await CreateBuilder(factory).BuildAsync(settings, "topic");
+
+        var tools = factory.Created.Single(agent => agent.Name == "Analyst").Tools!;
+        Assert.DoesNotContain(tools, tool => tool.Name == "ExecuteJsonTool");
+    }
+
     private static ConversationPipelineBuilder CreateBuilder(RecordingAgentFactory factory)
         => new(
             new ApplicationDataPathResolver(Path.Combine(Path.GetTempPath(), "coffeetalk-tests", Guid.NewGuid().ToString("N"))),


### PR DESCRIPTION
## Summary
- add optional persona tool allow-lists with validation
- filter tools at persona agent construction and block JSON dispatcher bypasses
- expose effective capabilities to orchestrator prompts and context
- add core pipeline and orchestrator coverage

## Validation
- dotnet test CoffeeTalk.Tests/CoffeeTalk.Tests.csproj --no-restore --verbosity minimal (71 passed)
- two independent read-only code-review passes completed; constructor compatibility finding addressed
- rebased onto latest main