### PR TITLE
Add PDF export for collaborative documents

### DIFF
--- a/CoffeeTalk.Core/CoffeeTalk.Core.csproj
+++ b/CoffeeTalk.Core/CoffeeTalk.Core.csproj
@@ -13,6 +13,8 @@
     <PackageReference Include="Microsoft.Agents.AI.OpenAI" Version="1.0.0-preview.251001.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.10" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.10" />
+    <!-- PdfSharpCore is MIT-licensed and avoids platform-specific GDI+ dependencies. -->
+    <PackageReference Include="PdfSharpCore" Version="1.3.65" />
   </ItemGroup>
 
 </Project>

--- a/CoffeeTalk.Core/Interfaces/IPdfDocumentExporter.cs
+++ b/CoffeeTalk.Core/Interfaces/IPdfDocumentExporter.cs
@@ -1,0 +1,6 @@
+namespace CoffeeTalk.Core.Interfaces;
+
+public interface IPdfDocumentExporter
+{
+    Task ExportAsync(string markdown, string outputPath, CancellationToken cancellationToken = default);
+}

--- a/CoffeeTalk.Core/Services/PdfDocumentExporter.cs
+++ b/CoffeeTalk.Core/Services/PdfDocumentExporter.cs
@@ -1,0 +1,102 @@
+using CoffeeTalk.Core.Interfaces;
+using PdfSharpCore.Drawing;
+using PdfSharpCore.Fonts;
+using PdfSharpCore.Pdf;
+using PdfSharpCore.Utils;
+
+namespace CoffeeTalk.Services;
+
+public sealed class PdfDocumentExporter : IPdfDocumentExporter
+{
+    public Task ExportAsync(string markdown, string outputPath, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(markdown);
+        ArgumentException.ThrowIfNullOrWhiteSpace(outputPath);
+        cancellationToken.ThrowIfCancellationRequested();
+        GlobalFontSettings.FontResolver ??= new SystemFontResolver();
+
+        using var document = new PdfDocument();
+        var font = new XFont("Arial", 11);
+        var headingFont = new XFont("Arial", 16, XFontStyle.Bold);
+        var lines = markdown.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
+        var lineIndex = 0;
+        while (lineIndex < lines.Length)
+        {
+            var page = document.AddPage();
+            using var graphics = XGraphics.FromPdfPage(page);
+            var y = 40d;
+            while (lineIndex < lines.Length)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var line = lines[lineIndex++];
+                var headingLength = GetHeadingLength(line);
+                var isHeading = headingLength > 0;
+                var text = isHeading ? line[(headingLength + 1)..] : line;
+                var lineHeight = isHeading ? 24d : 16d;
+                if (y + lineHeight > page.Height - 40)
+                {
+                    lineIndex--;
+                    break;
+                }
+
+                DrawLine(graphics, text, isHeading ? headingFont : font, ref y, lineHeight, page.Width);
+            }
+        }
+
+        Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+        document.Save(outputPath);
+        return Task.CompletedTask;
+    }
+
+    private static int GetHeadingLength(string line)
+    {
+        var length = 0;
+        while (length < line.Length && length < 6 && line[length] == '#')
+            length++;
+
+        return length > 0 && length < line.Length && line[length] == ' ' ? length : 0;
+    }
+
+    private sealed class SystemFontResolver : IFontResolver
+    {
+        private readonly string _fontPath = FindFontPath();
+
+        public string DefaultFontName => "Arial";
+
+        public FontResolverInfo ResolveTypeface(string familyName, bool isBold, bool isItalic) =>
+            new("CoffeeTalkSystemFont");
+
+        public byte[] GetFont(string faceName) => File.ReadAllBytes(_fontPath);
+
+        private static string FindFontPath()
+        {
+            var candidates = new[]
+            {
+                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Fonts), "arial.ttf"),
+                "/System/Library/Fonts/Supplemental/Arial.ttf",
+                "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+                "/usr/share/fonts/truetype/liberation2/LiberationSans-Regular.ttf"
+            };
+
+            return candidates.FirstOrDefault(File.Exists)
+                ?? throw new InvalidOperationException("No system TrueType font is available for PDF export.");
+        }
+    }
+
+    private static void DrawLine(
+        XGraphics graphics,
+        string text,
+        XFont font,
+        ref double y,
+        double lineHeight,
+        double pageWidth)
+    {
+        graphics.DrawString(
+            text,
+            font,
+            XBrushes.Black,
+            new XRect(40, y, pageWidth - 80, lineHeight),
+            XStringFormats.TopLeft);
+        y += lineHeight;
+    }
+}

--- a/CoffeeTalk.Gui/Components/ExportDialog.razor
+++ b/CoffeeTalk.Gui/Components/ExportDialog.razor
@@ -7,6 +7,7 @@
             <MudRadio Value="@("markdown")">Markdown (.md)</MudRadio>
             <MudRadio Value="@("html")">HTML (.html)</MudRadio>
             <MudRadio Value="@("json")">JSON (.json)</MudRadio>
+            <MudRadio Value="@("pdf")">PDF (.pdf)</MudRadio>
         </MudRadioGroup>
     </DialogContent>
     <DialogActions>

--- a/CoffeeTalk.Gui/Components/Pages/Conversation.razor
+++ b/CoffeeTalk.Gui/Components/Pages/Conversation.razor
@@ -11,6 +11,7 @@
 @inject IDialogService DialogService
 @inject IJSRuntime JSRuntime
 @inject IApplicationDataPathResolver DataPaths
+@inject IPdfDocumentExporter PdfExporter
 
 @if (UI.IsConversationRunning || !string.IsNullOrEmpty(UI.ConversationTopic))
 {
@@ -311,6 +312,15 @@
                     extension = "json";
                     mimeType = "application/json";
                     break;
+                case "pdf":
+                    extension = "pdf";
+                    var pdfTopic = MakeSafeFileNamePart(UI.ConversationTopic ?? "conversation");
+                    var pdfFileName = $"{pdfTopic}_{DateTime.Now:yyyyMMdd_HHmmss}.{extension}";
+                    var pdfPath = DataPaths.ResolveExportPath(pdfFileName, "conversation.pdf");
+                    Directory.CreateDirectory(Path.GetDirectoryName(pdfPath)!);
+                    await PdfExporter.ExportAsync(UI.DocumentMarkdown, pdfPath);
+                    Snackbar.Add($"Exported to {pdfPath}", Severity.Success);
+                    return;
                 default:
                     content = ConversationExportService.GenerateMarkdown(
                         UI.ConversationTopic,

--- a/CoffeeTalk.Gui/Program.cs
+++ b/CoffeeTalk.Gui/Program.cs
@@ -16,6 +16,7 @@ class Program
 
         appBuilder.Services.AddLogging();
         appBuilder.Services.AddSingleton<IApplicationDataPathResolver, ApplicationDataPathResolver>();
+        appBuilder.Services.AddSingleton<IPdfDocumentExporter, PdfDocumentExporter>();
         appBuilder.Services.AddSingleton<ConfigurationService>();
         appBuilder.Services.AddSingleton<AppState>();
         appBuilder.Services.AddSingleton<ConversationHistoryService>();

--- a/CoffeeTalk.Gui/_Imports.razor
+++ b/CoffeeTalk.Gui/_Imports.razor
@@ -1,3 +1,5 @@
 @using Microsoft.AspNetCore.Components.Web
 @using Microsoft.AspNetCore.Components.Routing
 @using MudBlazor
+@using CoffeeTalk.Services
+@using CoffeeTalk.Core.Interfaces

--- a/CoffeeTalk.Tests/ConversationComponentTests.cs
+++ b/CoffeeTalk.Tests/ConversationComponentTests.cs
@@ -3,6 +3,7 @@ using Bunit;
 using CoffeeTalk.Gui.Components;
 using CoffeeTalk.Gui.Services;
 using CoffeeTalk.Services;
+using CoffeeTalk.Core.Interfaces;
 using Microsoft.JSInterop;
 using Microsoft.Extensions.DependencyInjection;
 using MudBlazor.Services;
@@ -21,6 +22,7 @@ public class ConversationComponentTests : TestContext
         context.Services.AddSingleton<IApplicationDataPathResolver>(
             new ApplicationDataPathResolver(Path.Combine(Path.GetTempPath(), "coffeetalk-tests", Guid.NewGuid().ToString("N"))));
         context.Services.AddSingleton<MudBlazor.ISnackbar, MudBlazor.SnackbarService>();
+        context.Services.AddSingleton<IPdfDocumentExporter, PdfDocumentExporter>();
 
         var ui = new BlazorUserInterface();
         context.Services.AddSingleton(ui);

--- a/CoffeeTalk.Tests/PdfDocumentExporterTests.cs
+++ b/CoffeeTalk.Tests/PdfDocumentExporterTests.cs
@@ -1,0 +1,40 @@
+using CoffeeTalk.Core.Interfaces;
+using CoffeeTalk.Services;
+using System.Text;
+
+namespace CoffeeTalk.Tests;
+
+public sealed class PdfDocumentExporterTests
+{
+    [Fact]
+    public async Task ExportAsync_WritesPdfForCollaborativeMarkdown()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "coffeetalk-pdf-tests", Guid.NewGuid().ToString("N"));
+        var resolver = new ApplicationDataPathResolver(root);
+        var path = resolver.ResolveExportPath("final.pdf", "conversation.pdf");
+
+        try
+        {
+            IPdfDocumentExporter exporter = new PdfDocumentExporter();
+            await exporter.ExportAsync("# Final document\n\nA collaborative result.", path);
+
+            Assert.True(File.Exists(path));
+            var bytes = await File.ReadAllBytesAsync(path);
+            Assert.Equal("%PDF-", Encoding.ASCII.GetString(bytes, 0, 5));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ResolveExportPath_RejectsTraversalForPdfOutput()
+    {
+        var resolver = new ApplicationDataPathResolver(Path.Combine(Path.GetTempPath(), "coffeetalk-pdf-tests"));
+
+        Assert.Throws<UnauthorizedAccessException>(
+            () => resolver.ResolveExportPath("../final.pdf", "conversation.pdf"));
+    }
+}

--- a/CoffeeTalk/Program.cs
+++ b/CoffeeTalk/Program.cs
@@ -66,6 +66,16 @@ class Program
                 });
                 AnsiConsole.MarkupLine($"[green]Saved conversation {Markup.Escape(saveId)}[/]");
             }
+            var exportFormat = GetOption(args, "--export-format");
+            if (exportFormat is not null)
+            {
+                await ExportDocumentAsync(
+                    dataPaths,
+                    new PdfDocumentExporter(),
+                    exportFormat,
+                    ((ConsoleUserInterface)ui).DocumentContent,
+                    topic);
+            }
             AnsiConsole.MarkupLine("\n[bold green]Thank you for using CoffeeTalk! ☕[/]");
         }
         catch (OperationCanceledException ex)
@@ -119,5 +129,37 @@ class Program
         return index >= 0 && index + 1 < args.Length && !args[index + 1].StartsWith("-", StringComparison.Ordinal)
             ? args[index + 1]
             : null;
+    }
+
+    private static async Task ExportDocumentAsync(
+        IApplicationDataPathResolver dataPaths,
+        IPdfDocumentExporter pdfExporter,
+        string format,
+        string content,
+        string topic)
+    {
+        var normalizedFormat = format.ToLowerInvariant();
+        if (normalizedFormat is not ("markdown" or "md" or "pdf"))
+            throw new ArgumentException("Export format must be markdown or pdf.", nameof(format));
+
+        var extension = normalizedFormat == "pdf" ? "pdf" : "md";
+        var safeTopic = new string(topic.Select(character =>
+            Path.GetInvalidFileNameChars().Contains(character) || character is '/' or '\\'
+                ? '_'
+                : character).ToArray()).Trim();
+        safeTopic = string.IsNullOrWhiteSpace(safeTopic) ? "conversation" : safeTopic;
+        var path = dataPaths.ResolveExportPath(
+            $"{safeTopic}_{DateTime.Now:yyyyMMdd_HHmmss}.{extension}",
+            $"conversation.{extension}");
+
+        if (normalizedFormat == "pdf")
+            await pdfExporter.ExportAsync(content, path);
+        else
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            await File.WriteAllTextAsync(path, content);
+        }
+
+        AnsiConsole.MarkupLine($"[green]Exported to {Markup.Escape(path)}[/]");
     }
 }


### PR DESCRIPTION
Implements scoped issue #50 PDF export work.

- Adds injectable cross-platform PdfSharpCore PDF exporter with system-font resolution.
- Adds GUI PDF export for the final collaborative document while preserving existing HTML conversation export.
- Adds CLI --export-format markdown|md|pdf selection and focused export/path tests.
- Leaves persona-tool and conversation-persistence files unchanged.

Dependency: PdfSharpCore 1.3.65 (MIT; cross-platform .NET implementation with permissive Apache 2.0 transitive font/image dependencies).

Tests: dotnet test CoffeeTalk.Tests/CoffeeTalk.Tests.csproj --no-restore --nologo (69 passed).

Rebased onto latest origin/main before opening.