### PR TITLE
Fix backlog validation regressions

### DIFF
--- a/CoffeeTalk.Core/Services/PdfDocumentExporter.cs
+++ b/CoffeeTalk.Core/Services/PdfDocumentExporter.cs
@@ -120,57 +120,30 @@ public sealed class PdfDocumentExporter : IPdfDocumentExporter
         }
 
         var currentLine = string.Empty;
-        foreach (var word in text.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+        foreach (var character in text)
         {
-            if (graphics.MeasureString(word, font).Width > maxWidth)
+            var candidate = currentLine + character;
+            if (currentLine.Length == 0 || graphics.MeasureString(candidate, font).Width <= maxWidth)
             {
-                if (currentLine.Length > 0)
-                {
-                    yield return currentLine;
-                    currentLine = string.Empty;
-                }
-
-                foreach (var chunk in SplitLongWord(graphics, word, font, maxWidth))
-                    yield return chunk;
-
+                currentLine = candidate;
                 continue;
             }
 
-            var candidate = currentLine.Length == 0 ? word : $"{currentLine} {word}";
-            if (graphics.MeasureString(candidate, font).Width <= maxWidth)
+            var breakIndex = currentLine.LastIndexOfAny([' ', '\t']);
+            if (breakIndex >= 0)
             {
-                currentLine = candidate;
+                yield return currentLine[..(breakIndex + 1)];
+                currentLine = currentLine[(breakIndex + 1)..] + character;
             }
             else
             {
                 yield return currentLine;
-                currentLine = word;
+                currentLine = character.ToString();
             }
         }
 
         if (currentLine.Length > 0)
             yield return currentLine;
-    }
-
-    private static IEnumerable<string> SplitLongWord(XGraphics graphics, string word, XFont font, double maxWidth)
-    {
-        var chunk = string.Empty;
-        foreach (var character in word)
-        {
-            var candidate = chunk + character;
-            if (chunk.Length > 0 && graphics.MeasureString(candidate, font).Width > maxWidth)
-            {
-                yield return chunk;
-                chunk = character.ToString();
-            }
-            else
-            {
-                chunk = candidate;
-            }
-        }
-
-        if (chunk.Length > 0)
-            yield return chunk;
     }
 
     private readonly record struct PendingLine(string Text, XFont Font, double LineHeight);

--- a/CoffeeTalk.Core/Services/PdfDocumentExporter.cs
+++ b/CoffeeTalk.Core/Services/PdfDocumentExporter.cs
@@ -3,6 +3,7 @@ using PdfSharpCore.Drawing;
 using PdfSharpCore.Fonts;
 using PdfSharpCore.Pdf;
 using PdfSharpCore.Utils;
+using System.Text;
 
 namespace CoffeeTalk.Services;
 
@@ -38,7 +39,7 @@ public sealed class PdfDocumentExporter : IPdfDocumentExporter
                     var text = isHeading ? line[(headingLength + 1)..] : line;
                     var fontForLine = isHeading ? headingFont : font;
                     var lineHeight = isHeading ? 24d : 16d;
-                    foreach (var wrappedText in WrapText(graphics, text, fontForLine, page.Width - 80))
+                    foreach (var wrappedText in WrapText(graphics, text, fontForLine, page.Width - 80, cancellationToken))
                         pendingLines.Enqueue(new PendingLine(wrappedText, fontForLine, lineHeight));
                 }
 
@@ -111,7 +112,12 @@ public sealed class PdfDocumentExporter : IPdfDocumentExporter
         y += lineHeight;
     }
 
-    private static IEnumerable<string> WrapText(XGraphics graphics, string text, XFont font, double maxWidth)
+    private static IEnumerable<string> WrapText(
+        XGraphics graphics,
+        string text,
+        XFont font,
+        double maxWidth,
+        CancellationToken cancellationToken)
     {
         if (string.IsNullOrEmpty(text))
         {
@@ -120,8 +126,10 @@ public sealed class PdfDocumentExporter : IPdfDocumentExporter
         }
 
         var currentLine = string.Empty;
-        foreach (var character in text)
+        foreach (var rune in text.EnumerateRunes())
         {
+            cancellationToken.ThrowIfCancellationRequested();
+            var character = rune.ToString();
             var candidate = currentLine + character;
             if (currentLine.Length == 0 || graphics.MeasureString(candidate, font).Width <= maxWidth)
             {
@@ -138,7 +146,7 @@ public sealed class PdfDocumentExporter : IPdfDocumentExporter
             else
             {
                 yield return currentLine;
-                currentLine = character.ToString();
+                currentLine = character;
             }
         }
 

--- a/CoffeeTalk.Core/Services/PdfDocumentExporter.cs
+++ b/CoffeeTalk.Core/Services/PdfDocumentExporter.cs
@@ -20,26 +20,37 @@ public sealed class PdfDocumentExporter : IPdfDocumentExporter
         var headingFont = new XFont("Arial", 16, XFontStyle.Bold);
         var lines = markdown.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
         var lineIndex = 0;
-        while (lineIndex < lines.Length)
+        var pendingLines = new Queue<PendingLine>();
+        while (lineIndex < lines.Length || pendingLines.Count > 0)
         {
             var page = document.AddPage();
             using var graphics = XGraphics.FromPdfPage(page);
             var y = 40d;
-            while (lineIndex < lines.Length)
+            while (lineIndex < lines.Length || pendingLines.Count > 0)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                var line = lines[lineIndex++];
-                var headingLength = GetHeadingLength(line);
-                var isHeading = headingLength > 0;
-                var text = isHeading ? line[(headingLength + 1)..] : line;
-                var lineHeight = isHeading ? 24d : 16d;
-                if (y + lineHeight > page.Height - 40)
+
+                if (pendingLines.Count == 0)
                 {
-                    lineIndex--;
+                    var line = lines[lineIndex++];
+                    var headingLength = GetHeadingLength(line);
+                    var isHeading = headingLength > 0;
+                    var text = isHeading ? line[(headingLength + 1)..] : line;
+                    var fontForLine = isHeading ? headingFont : font;
+                    var lineHeight = isHeading ? 24d : 16d;
+                    foreach (var wrappedText in WrapText(graphics, text, fontForLine, page.Width - 80))
+                        pendingLines.Enqueue(new PendingLine(wrappedText, fontForLine, lineHeight));
+                }
+
+                var pendingLine = pendingLines.Peek();
+                var lineHeightForPage = pendingLine.LineHeight;
+                if (y + lineHeightForPage > page.Height - 40)
+                {
                     break;
                 }
 
-                DrawLine(graphics, text, isHeading ? headingFont : font, ref y, lineHeight, page.Width);
+                pendingLines.Dequeue();
+                DrawLine(graphics, pendingLine.Text, pendingLine.Font, ref y, lineHeightForPage, page.Width);
             }
         }
 
@@ -99,4 +110,68 @@ public sealed class PdfDocumentExporter : IPdfDocumentExporter
             XStringFormats.TopLeft);
         y += lineHeight;
     }
+
+    private static IEnumerable<string> WrapText(XGraphics graphics, string text, XFont font, double maxWidth)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            yield return string.Empty;
+            yield break;
+        }
+
+        var currentLine = string.Empty;
+        foreach (var word in text.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (graphics.MeasureString(word, font).Width > maxWidth)
+            {
+                if (currentLine.Length > 0)
+                {
+                    yield return currentLine;
+                    currentLine = string.Empty;
+                }
+
+                foreach (var chunk in SplitLongWord(graphics, word, font, maxWidth))
+                    yield return chunk;
+
+                continue;
+            }
+
+            var candidate = currentLine.Length == 0 ? word : $"{currentLine} {word}";
+            if (graphics.MeasureString(candidate, font).Width <= maxWidth)
+            {
+                currentLine = candidate;
+            }
+            else
+            {
+                yield return currentLine;
+                currentLine = word;
+            }
+        }
+
+        if (currentLine.Length > 0)
+            yield return currentLine;
+    }
+
+    private static IEnumerable<string> SplitLongWord(XGraphics graphics, string word, XFont font, double maxWidth)
+    {
+        var chunk = string.Empty;
+        foreach (var character in word)
+        {
+            var candidate = chunk + character;
+            if (chunk.Length > 0 && graphics.MeasureString(candidate, font).Width > maxWidth)
+            {
+                yield return chunk;
+                chunk = character.ToString();
+            }
+            else
+            {
+                chunk = candidate;
+            }
+        }
+
+        if (chunk.Length > 0)
+            yield return chunk;
+    }
+
+    private readonly record struct PendingLine(string Text, XFont Font, double LineHeight);
 }

--- a/CoffeeTalk.Gui/Components/Pages/Settings.razor
+++ b/CoffeeTalk.Gui/Components/Pages/Settings.razor
@@ -155,7 +155,10 @@
         var editablePersona = new PersonaConfig
         {
             Name = persona.Name,
-            SystemPrompt = persona.SystemPrompt
+            SystemPrompt = persona.SystemPrompt,
+            AllowedTools = persona.AllowedTools is null
+                ? null
+                : [.. persona.AllowedTools]
         };
         var parameters = new DialogParameters { ["Persona"] = editablePersona };
         var dialog = DialogService.Show<PersonaDialog>("Edit Persona", parameters);


### PR DESCRIPTION
Fixes two production defects found during final validation of merged PRs #103-#107:

- Wrap long PDF lines and continue them across page boundaries instead of clipping text.
- Preserve persona AllowedTools when editing settings so restrictions are not removed.

Validation: dotnet build CoffeeTalk.sln --configuration Release --no-restore; dotnet test CoffeeTalk.sln --configuration Release --no-build --no-restore (73 passed).