### PR TITLE
Add streaming conversation responses

### DIFF
--- a/CoffeeTalk.Core/Interfaces/IUserInterface.cs
+++ b/CoffeeTalk.Core/Interfaces/IUserInterface.cs
@@ -10,6 +10,7 @@ namespace CoffeeTalk.Core.Interfaces
         Task ShowMessageAsync(string message);
         Task ShowErrorAsync(string message);
         Task ShowAgentResponseAsync(string agentName, string response);
+        Task ShowAgentResponseChunkAsync(string agentName, string chunk);
         Task ShowDocumentPreviewAsync(string content);
         Task<(string Action, string Message)> GetUserInterventionAsync();
 

--- a/CoffeeTalk.Core/Models/AppSettings.cs
+++ b/CoffeeTalk.Core/Models/AppSettings.cs
@@ -50,5 +50,8 @@ public class PersistedLlmProviderConfig
     public string Endpoint { get; set; } = string.Empty;
     public string ModelId { get; set; } = string.Empty;
     public string DeploymentName { get; set; } = string.Empty;
+    public bool StreamingEnabled { get; set; } = true;
+    public bool? StreamingSupported { get; set; }
+    public string StreamingFallback { get; set; } = "buffered";
     // ApiKey is intentionally omitted
 }

--- a/CoffeeTalk.Core/Models/LlmProviderConfig.cs
+++ b/CoffeeTalk.Core/Models/LlmProviderConfig.cs
@@ -6,6 +6,9 @@ public class LlmProviderConfig
     public string ApiKey { get; set; } = string.Empty;
     public string Endpoint { get; set; } = string.Empty;
     public string ModelId { get; set; } = string.Empty;
+    public bool StreamingEnabled { get; set; } = true;
+    public bool? StreamingSupported { get; set; }
+    public string StreamingFallback { get; set; } = "buffered"; // "buffered" or "error"
     // For Azure OpenAI the "ModelId" represents DeploymentName in Azure terms, but
     // provide an explicit property to be clearer in config files.
     public string? DeploymentName { get; set; }

--- a/CoffeeTalk.Core/Services/AgentConversationOrchestrator.cs
+++ b/CoffeeTalk.Core/Services/AgentConversationOrchestrator.cs
@@ -118,7 +118,7 @@ public class AgentConversationOrchestrator
                     if (selectedPersona != null)
                     {
                         await _ui.SetStatusAsync($"{Escape(selectedPersona.Name)} is thinking...");
-                        response = await selectedPersona.RespondAsync(currentMessage, conversationHistory, cancellationToken);
+                        response = await StreamResponseAsync(selectedPersona, currentMessage, conversationHistory, cancellationToken);
                     }
                 });
 
@@ -129,7 +129,6 @@ public class AgentConversationOrchestrator
                 }
 
                 await _ui.ShowAgentResponseAsync(selectedPersona.Name, response);
-                
                 conversationHistory.Add($"{selectedPersona.Name}: {response}");
                 currentMessage = response;
                 totalTurns++;
@@ -236,16 +235,15 @@ public class AgentConversationOrchestrator
                     {
                         await _ui.RunWithStatusAsync($"{Escape(persona.Name)} is thinking...", async () =>
                         {
-                            response = await persona.RespondAsync(currentMessage, conversationHistory, cancellationToken);
+                            response = await StreamResponseAsync(persona, currentMessage, conversationHistory, cancellationToken);
                         });
                     }
                     else
                     {
-                        response = await persona.RespondAsync(currentMessage, conversationHistory, cancellationToken);
+                        response = await StreamResponseAsync(persona, currentMessage, conversationHistory, cancellationToken);
                     }
 
                     await _ui.ShowAgentResponseAsync(persona.Name, response);
-                    
                     conversationHistory.Add($"{persona.Name}: {response}");
                     currentMessage = response;
                     totalTurns++;
@@ -351,6 +349,35 @@ public class AgentConversationOrchestrator
         }
 
         await TryAutoSaveAsync(cancellationToken);
+    }
+
+    private async Task<string> StreamResponseAsync(
+        AgentPersona persona,
+        string currentMessage,
+        List<string> conversationHistory,
+        CancellationToken cancellationToken)
+    {
+        var response = new StringBuilder();
+        try
+        {
+            await foreach (var chunk in persona.RespondStreamingAsync(
+                currentMessage,
+                conversationHistory,
+                cancellationToken))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                response.Append(chunk);
+                await _ui.ShowAgentResponseChunkAsync(persona.Name, chunk);
+            }
+        }
+        catch
+        {
+            if (response.Length > 0)
+                await _ui.ShowAgentResponseAsync(persona.Name, response.ToString());
+            throw;
+        }
+
+        return response.ToString();
     }
 
     private async Task RunEditorIntervention(List<string> conversationHistory, CancellationToken cancellationToken)

--- a/CoffeeTalk.Core/Services/AgentPersona.cs
+++ b/CoffeeTalk.Core/Services/AgentPersona.cs
@@ -1,6 +1,7 @@
 using Microsoft.Agents.AI;
 using CoffeeTalk.Core.Interfaces;
 using CoffeeTalk.Models;
+using System.Runtime.CompilerServices;
 
 namespace CoffeeTalk.Services;
 
@@ -16,6 +17,7 @@ public class AgentPersona
     private readonly int _maxTurns;
     private readonly int _agentCount;
     private readonly IRetryService _retryService;
+    private readonly LlmProviderConfig _providerConfig;
 
     public string Name => _config.Name;
     public string SystemPrompt => _config.SystemPrompt;
@@ -29,7 +31,8 @@ public class AgentPersona
         int maxTurns,
         int agentCount,
         IRetryService retryService,
-        IReadOnlyCollection<string>? effectiveToolNames = null)
+        IReadOnlyCollection<string>? effectiveToolNames = null,
+        LlmProviderConfig? providerConfig = null)
     {
         _agent = agent;
         _config = config;
@@ -38,6 +41,7 @@ public class AgentPersona
         _maxTurns = maxTurns;
         _agentCount = agentCount;
         _retryService = retryService;
+        _providerConfig = providerConfig ?? new LlmProviderConfig();
         EffectiveToolNames = effectiveToolNames?.ToList() ?? [];
     }
 
@@ -66,29 +70,7 @@ public class AgentPersona
 
     public async Task<string> RespondAsync(string currentMessage, List<string> conversationHistory, CancellationToken cancellationToken = default)
     {
-        // Build context from recent conversation history (last 3 messages to reduce tokens)
-        var recentHistory = conversationHistory.TakeLast(3).ToList();
-        var contextMessage = recentHistory.Count > 0
-            ? $"Recent conversation:\n{string.Join("\n", recentHistory)}\n\nCurrent message: {currentMessage}"
-            : currentMessage;
-
-        // Add current document state as context
-        var docState = GetDocumentState();
-        if (!string.IsNullOrWhiteSpace(docState))
-        {
-            contextMessage = $"Current document state:\n{docState}\n\n{contextMessage}";
-        }
-
-        // Calculate current turn number
-        var currentTurn = (conversationHistory.Count / _agentCount) + 1;
-        var turnsRemaining = _maxTurns - currentTurn;
-        if (turnsRemaining <= 2)
-        {
-            contextMessage = $"⚠️ IMPORTANT: Only {turnsRemaining} turn(s) remaining. Focus on wrapping up and reaching a clear conclusion.\n\n{contextMessage}";
-        }
-
-        // Add collaboration guidelines as context
-        contextMessage = $"{GetPersonaCollaborationGuidelines()}\n\n{contextMessage}";
+        var contextMessage = BuildContext(currentMessage, conversationHistory);
 
         // Throttle based on an estimated token count
         var estimatedTokens = _rateLimiter?.EstimateTokens(contextMessage) ?? 0;
@@ -129,6 +111,119 @@ public class AgentPersona
 
         return responseText;
     }
+
+    public async IAsyncEnumerable<string> RespondStreamingAsync(
+        string currentMessage,
+        List<string> conversationHistory,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var contextMessage = BuildContext(currentMessage, conversationHistory);
+        var estimatedTokens = _rateLimiter?.EstimateTokens(contextMessage) ?? 0;
+        if (_rateLimiter != null)
+            await _rateLimiter.ThrottleAsync(estimatedTokens, cancellationToken);
+
+        if (!_providerConfig.StreamingEnabled || !SupportsStreaming())
+        {
+            if (UseBufferedFallback())
+            {
+                await foreach (var chunk in FallbackToBufferedAsync(contextMessage, cancellationToken))
+                    yield return chunk;
+            }
+            else
+            {
+                throw new NotSupportedException(
+                    $"Streaming is not available for provider '{_providerConfig.Type}'.");
+            }
+            yield break;
+        }
+
+        var emitted = false;
+        Exception? failure = null;
+        await using var updates = _agent.RunStreamingAsync(
+            contextMessage,
+            cancellationToken: cancellationToken).GetAsyncEnumerator(cancellationToken);
+        while (true)
+        {
+            bool hasUpdate;
+            try
+            {
+                hasUpdate = await updates.MoveNextAsync();
+            }
+            catch (Exception ex)
+            {
+                failure = ex;
+                break;
+            }
+
+            if (!hasUpdate)
+                break;
+
+            cancellationToken.ThrowIfCancellationRequested();
+            var text = updates.Current.Text;
+            if (string.IsNullOrEmpty(text))
+                continue;
+
+            emitted = true;
+            yield return text;
+        }
+
+        if (failure is OperationCanceledException)
+            throw failure;
+        if (failure is not null && emitted)
+            throw failure;
+        if (failure is not null && UseBufferedFallback())
+        {
+            await foreach (var chunk in FallbackToBufferedAsync(contextMessage, cancellationToken))
+                yield return chunk;
+        }
+        else if (failure is not null)
+        {
+            throw failure;
+        }
+    }
+
+    private async IAsyncEnumerable<string> FallbackToBufferedAsync(
+        string contextMessage,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        var response = await _retryService.ExecuteAsync(
+            async token => await _agent.RunAsync(contextMessage, cancellationToken: token),
+            $"{Name} response",
+            cancellationToken);
+        var responseText = response.ToString();
+        _rateLimiter?.AccountAdditionalTokens(_rateLimiter.EstimateTokens(responseText));
+        yield return responseText;
+    }
+
+    private string BuildContext(string currentMessage, List<string> conversationHistory)
+    {
+        var recentHistory = conversationHistory.TakeLast(3).ToList();
+        var contextMessage = recentHistory.Count > 0
+            ? $"Recent conversation:\n{string.Join("\n", recentHistory)}\n\nCurrent message: {currentMessage}"
+            : currentMessage;
+        var docState = GetDocumentState();
+        if (!string.IsNullOrWhiteSpace(docState))
+            contextMessage = $"Current document state:\n{docState}\n\n{contextMessage}";
+
+        var currentTurn = (conversationHistory.Count / _agentCount) + 1;
+        var turnsRemaining = _maxTurns - currentTurn;
+        if (turnsRemaining <= 2)
+            contextMessage = $"⚠️ IMPORTANT: Only {turnsRemaining} turn(s) remaining. Focus on wrapping up and reaching a clear conclusion.\n\n{contextMessage}";
+
+        return $"{GetPersonaCollaborationGuidelines()}\n\n{contextMessage}";
+    }
+
+    private bool SupportsStreaming()
+    {
+        if (_providerConfig.StreamingSupported.HasValue)
+            return _providerConfig.StreamingSupported.Value;
+
+        return _providerConfig.Type.Equals("openai", StringComparison.OrdinalIgnoreCase) ||
+               _providerConfig.Type.Equals("azureopenai", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private bool UseBufferedFallback() =>
+        _providerConfig.StreamingFallback.Equals("buffered", StringComparison.OrdinalIgnoreCase);
 
     private string GetPersonaCollaborationGuidelines()
     {

--- a/CoffeeTalk.Core/Services/ConfigurationService.cs
+++ b/CoffeeTalk.Core/Services/ConfigurationService.cs
@@ -65,7 +65,10 @@ public class ConfigurationService
                 Type = settings.LlmProvider.Type,
                 Endpoint = settings.LlmProvider.Endpoint,
                 ModelId = settings.LlmProvider.ModelId,
-                DeploymentName = settings.LlmProvider.DeploymentName ?? string.Empty
+                DeploymentName = settings.LlmProvider.DeploymentName ?? string.Empty,
+                StreamingEnabled = settings.LlmProvider.StreamingEnabled,
+                StreamingSupported = settings.LlmProvider.StreamingSupported,
+                StreamingFallback = settings.LlmProvider.StreamingFallback
                 // ApiKey is intentionally omitted
             },
             Personas = settings.Personas,

--- a/CoffeeTalk.Core/Services/ConversationPipelineBuilder.cs
+++ b/CoffeeTalk.Core/Services/ConversationPipelineBuilder.cs
@@ -287,7 +287,8 @@ public sealed class ConversationPipelineBuilder
             settings.MaxConversationTurns,
             totalPersonaCount ?? agentCount,
             retryService,
-            personaTools.Select(tool => tool.Name).ToList());
+            personaTools.Select(tool => tool.Name).ToList(),
+            settings.LlmProvider);
     }
 
     private static void ValidateAllowedTools(IEnumerable<PersonaConfig> configs, AIFunction[] tools)

--- a/CoffeeTalk.Gui/Services/BlazorUserInterface.cs
+++ b/CoffeeTalk.Gui/Services/BlazorUserInterface.cs
@@ -11,6 +11,7 @@ namespace CoffeeTalk.Gui.Services
 
         // Chat History
         private readonly object _messagesLock = new();
+        private ChatMessage? _streamingMessage;
         public List<ChatMessage> Messages { get; } = new();
         public IReadOnlyList<ChatMessage> GetMessagesSnapshot()
         {
@@ -66,7 +67,37 @@ namespace CoffeeTalk.Gui.Services
         {
             CurrentThinkingPersona = null;
             lock (_messagesLock)
-                Messages.Add(new ChatMessage { Sender = agentName, Content = response });
+            {
+                if (_streamingMessage is not null && _streamingMessage.Sender == agentName)
+                {
+                    _streamingMessage.Content = response;
+                    _streamingMessage = null;
+                }
+                else
+                {
+                    Messages.Add(new ChatMessage { Sender = agentName, Content = response });
+                }
+            }
+            NotifyStateChanged();
+            return Task.CompletedTask;
+        }
+
+        public Task ShowAgentResponseChunkAsync(string agentName, string chunk)
+        {
+            CurrentThinkingPersona = null;
+            lock (_messagesLock)
+            {
+                _streamingMessage ??= new ChatMessage { Sender = agentName };
+                if (_streamingMessage.Sender != agentName)
+                {
+                    _streamingMessage = new ChatMessage { Sender = agentName };
+                    Messages.Add(_streamingMessage);
+                }
+
+                if (!Messages.Contains(_streamingMessage))
+                    Messages.Add(_streamingMessage);
+                _streamingMessage.Content += chunk;
+            }
             NotifyStateChanged();
             return Task.CompletedTask;
         }
@@ -186,7 +217,10 @@ namespace CoffeeTalk.Gui.Services
         {
             CancelIntervention();
             lock (_messagesLock)
+            {
                 Messages.Clear();
+                _streamingMessage = null;
+            }
             StopRequested = false;
             ConversationTopic = null;
             ConversationParticipants = Array.Empty<string>();
@@ -206,6 +240,7 @@ namespace CoffeeTalk.Gui.Services
             lock (_messagesLock)
             {
                 Messages.Clear();
+                _streamingMessage = null;
                 Messages.AddRange(record.Messages.Select(message => new ChatMessage
                 {
                     Sender = message.Sender,

--- a/CoffeeTalk.Tests/AgentPersonaTests.cs
+++ b/CoffeeTalk.Tests/AgentPersonaTests.cs
@@ -22,4 +22,78 @@ public sealed class AgentPersonaTests
         Assert.Equal("Error: An unexpected error occurred.", result);
         Assert.DoesNotContain(secret, result);
     }
+
+    [Fact]
+    public async Task RespondStreamingAsync_EmitsChunksAndPreservesOrder()
+    {
+        var agent = new TestAIAgent(
+            "buffered",
+            ["first ", "second"],
+            new InvalidOperationException("stream failed after output"));
+        var persona = new AgentPersona(
+            agent,
+            new PersonaConfig { Name = "Analyst", SystemPrompt = "You are Analyst." },
+            new CollaborativeMarkdownDocument(),
+            null,
+            maxTurns: 2,
+            agentCount: 1,
+            retryService: new RetryService(null),
+            providerConfig: new LlmProviderConfig { Type = "openai" });
+
+        var chunks = new List<string>();
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await foreach (var chunk in persona.RespondStreamingAsync("topic", []))
+                chunks.Add(chunk);
+        });
+
+        Assert.Equal(["first ", "second"], chunks);
+        Assert.Equal(0, agent.Calls);
+        Assert.Equal(1, agent.StreamingCalls);
+    }
+
+    [Fact]
+    public async Task RespondStreamingAsync_UsesBufferedFallbackForUnsupportedOllama()
+    {
+        var agent = new TestAIAgent("buffered");
+        var persona = new AgentPersona(
+            agent,
+            new PersonaConfig { Name = "Analyst", SystemPrompt = "You are Analyst." },
+            new CollaborativeMarkdownDocument(),
+            null,
+            maxTurns: 2,
+            agentCount: 1,
+            retryService: new RetryService(null),
+            providerConfig: new LlmProviderConfig { Type = "ollama" });
+
+        var chunks = new List<string>();
+        await foreach (var chunk in persona.RespondStreamingAsync("topic", []))
+            chunks.Add(chunk);
+
+        Assert.Equal(["buffered"], chunks);
+        Assert.Equal(1, agent.Calls);
+        Assert.Equal(0, agent.StreamingCalls);
+    }
+
+    [Fact]
+    public async Task RespondStreamingAsync_PropagatesCancellationDuringEnumeration()
+    {
+        var agent = new TestAIAgent("buffered", ["first ", "second"]);
+        var persona = new AgentPersona(
+            agent,
+            new PersonaConfig { Name = "Analyst", SystemPrompt = "You are Analyst." },
+            new CollaborativeMarkdownDocument(),
+            null,
+            maxTurns: 2,
+            agentCount: 1,
+            retryService: new RetryService(null),
+            providerConfig: new LlmProviderConfig { Type = "openai" });
+        using var cancellation = new CancellationTokenSource();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        {
+            await foreach (var _ in persona.RespondStreamingAsync("topic", [], cancellation.Token))
+                cancellation.Cancel();
+        });
+    }
 }

--- a/CoffeeTalk.Tests/TestAIAgent.cs
+++ b/CoffeeTalk.Tests/TestAIAgent.cs
@@ -7,16 +7,27 @@ namespace CoffeeTalk.Tests;
 internal sealed class TestAIAgent : AIAgent
 {
     private readonly Func<AgentRunResponse> _response;
+    private readonly IReadOnlyList<string> _streamingChunks;
+    private readonly Exception? _streamingException;
     public int Calls { get; private set; }
+    public int StreamingCalls { get; private set; }
 
     public TestAIAgent(Func<AgentRunResponse> response)
     {
         _response = response;
+        _streamingChunks = [];
     }
 
     public TestAIAgent(string response)
         : this(() => new AgentRunResponse(new ChatMessage(ChatRole.Assistant, response)))
     {
+    }
+
+    public TestAIAgent(string response, IReadOnlyList<string> streamingChunks, Exception? streamingException = null)
+        : this(() => new AgentRunResponse(new ChatMessage(ChatRole.Assistant, response)))
+    {
+        _streamingChunks = streamingChunks;
+        _streamingException = streamingException;
     }
 
     public TestAIAgent(Exception exception)
@@ -48,7 +59,21 @@ internal sealed class TestAIAgent : AIAgent
         AgentRunOptions? options = null,
         [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        await Task.CompletedTask;
-        yield break;
+        StreamingCalls++;
+        foreach (var chunk in _streamingChunks)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return new AgentRunResponseUpdate(new ChatResponseUpdate(ChatRole.Assistant, chunk));
+            await Task.Yield();
+        }
+
+        if (_streamingChunks.Count == 0)
+        {
+            var response = _response();
+            yield return new AgentRunResponseUpdate(new ChatResponseUpdate(ChatRole.Assistant, response.ToString()));
+        }
+
+        if (_streamingException is not null)
+            throw _streamingException;
     }
 }

--- a/CoffeeTalk/Services/ConsoleUserInterface.cs
+++ b/CoffeeTalk/Services/ConsoleUserInterface.cs
@@ -14,6 +14,7 @@ namespace CoffeeTalk.Services
         public DateTimeOffset? ConversationStartedAt { get; private set; }
         public string DocumentContent { get; private set; } = string.Empty;
         public List<ConsoleMessage> Messages { get; } = new();
+        private int? _streamingMessageIndex;
 
         public Task ShowMessageAsync(string message)
         {
@@ -31,12 +32,36 @@ namespace CoffeeTalk.Services
 
         public Task ShowAgentResponseAsync(string agentName, string response)
         {
+            if (_streamingMessageIndex is int index)
+            {
+                Messages[index] = Messages[index] with { Content = response };
+                AnsiConsole.WriteLine();
+                _streamingMessageIndex = null;
+                return Task.CompletedTask;
+            }
+
             Messages.Add(new ConsoleMessage(agentName, response, false, false, false));
             var panel = new Panel(new Text(response))
                 .Header($"[bold]{Markup.Escape(agentName)}[/]")
                 .Border(BoxBorder.Rounded);
 
             AnsiConsole.Write(panel);
+            return Task.CompletedTask;
+        }
+
+        public Task ShowAgentResponseChunkAsync(string agentName, string chunk)
+        {
+            if (_streamingMessageIndex is not int index)
+            {
+                Messages.Add(new ConsoleMessage(agentName, string.Empty, false, false, false));
+                AnsiConsole.Markup($"[bold]{Markup.Escape(agentName)}[/] ");
+                index = Messages.Count - 1;
+                _streamingMessageIndex = index;
+            }
+
+            var message = Messages[index];
+            Messages[index] = message with { Content = message.Content + chunk };
+            AnsiConsole.Write(new Text(chunk));
             return Task.CompletedTask;
         }
 

--- a/CoffeeTalk/appsettings.example.json
+++ b/CoffeeTalk/appsettings.example.json
@@ -7,7 +7,9 @@
     "ApiKey": "sk-your-api-key-here",
     "Endpoint": "https://api.openai.com/v1",
     "ModelId": "gpt-4o-mini",
-    "DeploymentName": "your-deployment-name"
+    "DeploymentName": "your-deployment-name",
+    "StreamingEnabled": true,
+    "StreamingFallback": "buffered"
   },
   "Personas": [
     {

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A .NET CLI application that orchestrates multi-persona LLM conversations using M
 
 ### Core Capabilities
 - **Multiple LLM Providers**: Support for OpenAI, Azure OpenAI, and Ollama (local models)
+- **Streaming Responses**: OpenAI and Azure OpenAI responses stream by default, with configurable buffered fallback
 - **Configurable Personas**: Define multiple personas with unique system prompts and conversation styles
 - **Dynamic Persona Generation**: Automatically generate topic-specific personas at runtime using AI
 - **AI-Directed Orchestration**: Optional orchestrator agent intelligently selects which persona should speak next based on conversation needs
@@ -128,6 +129,15 @@ The conversation is auto-saved to `conversation.md` in the CoffeeTalk directory.
 ### LLM Provider Options
 
 CoffeeTalk supports three LLM provider types, each with different configuration requirements.
+
+### Streaming Responses
+
+Streaming is enabled by default for OpenAI and Azure OpenAI. Set `StreamingFallback` to
+`"error"` to fail instead of using the buffered `RunAsync` path when streaming is unavailable;
+the default `"buffered"` value preserves compatibility. Ollama streaming is conditional on
+the active model/server and is not assumed to be universally supported. To opt in after
+verifying a live Ollama setup, set `StreamingSupported` to `true`; otherwise CoffeeTalk uses
+the buffered path.
 
 #### OpenAI
 


### PR DESCRIPTION
## Summary
- stream persona responses through OpenAI and Azure OpenAI agents
- preserve buffered RunAsync fallback with configurable provider behavior
- propagate cancellation and avoid fallback/retry after partial output
- treat Ollama streaming as opt-in after a live capability probe
- update UI, configuration docs, and focused tests

HTTP API/webhook work is intentionally excluded.