### PR TITLE
Add isolated workspace management

### DIFF
--- a/CoffeeTalk.Core/Models/Workspace.cs
+++ b/CoffeeTalk.Core/Models/Workspace.cs
@@ -1,0 +1,11 @@
+namespace CoffeeTalk.Models;
+
+public sealed class WorkspaceMetadata
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string? Topic { get; set; }
+    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+    public DateTimeOffset LastUsedAt { get; set; } = DateTimeOffset.UtcNow;
+}
+

--- a/CoffeeTalk.Core/Services/ApplicationDataPathResolver.cs
+++ b/CoffeeTalk.Core/Services/ApplicationDataPathResolver.cs
@@ -8,21 +8,43 @@ public interface IApplicationDataPathResolver
     string ResolveExportPath(string? path, string defaultFileName);
 }
 
-public sealed class ApplicationDataPathResolver : IApplicationDataPathResolver
+public interface IWorkspacePathResolver : IApplicationDataPathResolver
 {
-    private readonly string _exportDirectory;
+    string BaseRootDirectory { get; }
+    string? WorkspaceName { get; }
+    void SwitchWorkspace(string? workspaceName);
+}
 
-    public ApplicationDataPathResolver(string? rootDirectory = null)
+public sealed class ApplicationDataPathResolver : IWorkspacePathResolver
+{
+    private readonly string _baseRootDirectory;
+    private string _exportDirectory = string.Empty;
+
+    public ApplicationDataPathResolver(string? rootDirectory = null, string? workspaceName = null)
     {
-        RootDirectory = Path.GetFullPath(rootDirectory ?? Path.Combine(
+        _baseRootDirectory = Path.GetFullPath(rootDirectory ?? Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
             "CoffeeTalk"));
+        SwitchWorkspace(workspaceName);
+    }
+
+    public string BaseRootDirectory => _baseRootDirectory;
+    public string RootDirectory { get; private set; } = string.Empty;
+    public string? WorkspaceName { get; private set; }
+    public string ConfigurationFilePath { get; private set; } = string.Empty;
+
+    public void SwitchWorkspace(string? workspaceName)
+    {
+        if (!string.IsNullOrWhiteSpace(workspaceName))
+            WorkspaceNameValidator.Validate(workspaceName);
+
+        WorkspaceName = string.IsNullOrWhiteSpace(workspaceName) ? null : workspaceName;
+        RootDirectory = WorkspaceName is null
+            ? _baseRootDirectory
+            : Path.Combine(_baseRootDirectory, "workspaces", WorkspaceName);
         _exportDirectory = Path.Combine(RootDirectory, "exports");
         ConfigurationFilePath = Path.Combine(RootDirectory, "appsettings.json");
     }
-
-    public string RootDirectory { get; }
-    public string ConfigurationFilePath { get; }
 
     public string ResolveDataPath(string? path, string defaultFileName) =>
         ResolveWithin(RootDirectory, path, defaultFileName);
@@ -47,6 +69,16 @@ public sealed class ApplicationDataPathResolver : IApplicationDataPathResolver
             throw new UnauthorizedAccessException("Path escapes the CoffeeTalk data directory.");
         }
 
+        var current = fullRoot;
+        if (Directory.Exists(current) && File.GetAttributes(current).HasFlag(FileAttributes.ReparsePoint))
+            throw new UnauthorizedAccessException("Reparse points are not allowed in the data directory.");
+        foreach (var segment in Path.GetRelativePath(fullRoot, fullPath)
+                     .Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries))
+        {
+            current = Path.Combine(current, segment);
+            if (Directory.Exists(current) && File.GetAttributes(current).HasFlag(FileAttributes.ReparsePoint))
+                throw new UnauthorizedAccessException("Reparse points are not allowed in the data directory.");
+        }
         return fullPath;
     }
 }

--- a/CoffeeTalk.Core/Services/WorkspaceService.cs
+++ b/CoffeeTalk.Core/Services/WorkspaceService.cs
@@ -1,0 +1,223 @@
+using System.Text.Json;
+using CoffeeTalk.Models;
+
+namespace CoffeeTalk.Services;
+
+public interface IWorkspaceService
+{
+    WorkspaceMetadata Active { get; }
+    Task<IReadOnlyList<WorkspaceMetadata>> ListAsync(CancellationToken cancellationToken = default);
+    Task<WorkspaceMetadata> CreateAsync(string name, CancellationToken cancellationToken = default);
+    Task<WorkspaceMetadata> SwitchAsync(string idOrName, CancellationToken cancellationToken = default);
+    Task DeleteAsync(string idOrName, CancellationToken cancellationToken = default);
+}
+
+public sealed class WorkspaceService : IWorkspaceService
+{
+    private const string WorkspaceDirectory = "workspaces";
+    private const string MetadataFile = "workspace.json";
+    private const string ActiveFile = "active-workspace.json";
+    private readonly IWorkspacePathResolver _paths;
+    private readonly string _workspaceRoot;
+    private readonly JsonSerializerOptions _json = new(JsonSerializerDefaults.Web) { WriteIndented = true };
+
+    public WorkspaceService(IWorkspacePathResolver paths)
+    {
+        _paths = paths ?? throw new ArgumentNullException(nameof(paths));
+        _workspaceRoot = Path.Combine(_paths.BaseRootDirectory, WorkspaceDirectory);
+        Active = EnsureActiveWorkspace();
+    }
+
+    public WorkspaceMetadata Active { get; private set; }
+
+    public async Task<IReadOnlyList<WorkspaceMetadata>> ListAsync(CancellationToken cancellationToken = default)
+    {
+        Directory.CreateDirectory(_workspaceRoot);
+        var result = new List<WorkspaceMetadata>();
+        foreach (var directory in Directory.EnumerateDirectories(_workspaceRoot))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (File.GetAttributes(directory).HasFlag(FileAttributes.ReparsePoint))
+                continue;
+            var metadata = await ReadMetadataAsync(directory, Path.GetFileName(directory), cancellationToken);
+            if (metadata is not null)
+                result.Add(metadata);
+        }
+        return result.OrderBy(x => x.Name, StringComparer.OrdinalIgnoreCase).ToList();
+    }
+
+    public async Task<WorkspaceMetadata> CreateAsync(string name, CancellationToken cancellationToken = default)
+    {
+        var normalizedName = name.Trim();
+        if (string.IsNullOrWhiteSpace(normalizedName))
+            throw new ArgumentException("A workspace name is required.", nameof(name));
+        var id = WorkspaceNameValidator.ToId(normalizedName);
+        var path = Path.Combine(_workspaceRoot, id);
+        if (Directory.Exists(path))
+            throw new InvalidOperationException($"Workspace '{normalizedName}' already exists.");
+
+        Directory.CreateDirectory(path);
+        var metadata = new WorkspaceMetadata { Id = id, Name = normalizedName };
+        await WriteMetadataAsync(path, metadata, cancellationToken);
+        return metadata;
+    }
+
+    public async Task<WorkspaceMetadata> SwitchAsync(string idOrName, CancellationToken cancellationToken = default)
+    {
+        var workspace = await FindAsync(idOrName, cancellationToken)
+            ?? throw new KeyNotFoundException($"Workspace '{idOrName}' was not found.");
+        Active = workspace;
+        _paths.SwitchWorkspace(workspace.Id);
+        await File.WriteAllTextAsync(
+            Path.Combine(_paths.BaseRootDirectory, ActiveFile),
+            JsonSerializer.Serialize(new { id = workspace.Id }, _json),
+            cancellationToken);
+        return workspace;
+    }
+
+    public async Task DeleteAsync(string idOrName, CancellationToken cancellationToken = default)
+    {
+        var workspace = await FindAsync(idOrName, cancellationToken)
+            ?? throw new KeyNotFoundException($"Workspace '{idOrName}' was not found.");
+        if (workspace.Id.Equals(Active.Id, StringComparison.Ordinal))
+        {
+            var replacement = (await ListAsync(cancellationToken))
+                .FirstOrDefault(x => !x.Id.Equals(workspace.Id, StringComparison.Ordinal));
+            if (replacement is null)
+                throw new InvalidOperationException("The only workspace cannot be deleted.");
+            await SwitchAsync(replacement.Id, cancellationToken);
+        }
+
+        var path = ResolveWorkspacePath(workspace.Id);
+        Directory.Delete(path, true);
+    }
+
+    private async Task<WorkspaceMetadata?> FindAsync(string idOrName, CancellationToken cancellationToken)
+        => (await ListAsync(cancellationToken)).FirstOrDefault(x =>
+            x.Id.Equals(idOrName, StringComparison.OrdinalIgnoreCase) ||
+            x.Name.Equals(idOrName, StringComparison.OrdinalIgnoreCase));
+
+    private WorkspaceMetadata EnsureActiveWorkspace()
+    {
+        Directory.CreateDirectory(_workspaceRoot);
+        var activeId = ReadActiveId();
+        WorkspaceMetadata? metadata = null;
+        if (activeId is not null)
+        {
+            try
+            {
+                metadata = ReadMetadataAsync(
+                    ResolveWorkspacePath(activeId), activeId, CancellationToken.None).GetAwaiter().GetResult();
+            }
+            catch (UnauthorizedAccessException) { }
+        }
+        if (metadata is null)
+        {
+            metadata = ReadMetadataAsync(ResolveWorkspacePath("default"), "default", CancellationToken.None).GetAwaiter().GetResult();
+            if (metadata is null)
+            {
+                var path = ResolveWorkspacePath("default");
+                Directory.CreateDirectory(path);
+                MigrateLegacyFiles(path);
+                metadata = new WorkspaceMetadata { Id = "default", Name = "Default" };
+                WriteMetadataAsync(path, metadata, CancellationToken.None).GetAwaiter().GetResult();
+            }
+            File.WriteAllText(Path.Combine(_paths.BaseRootDirectory, ActiveFile),
+                JsonSerializer.Serialize(new { id = metadata.Id }, _json));
+        }
+        _paths.SwitchWorkspace(metadata.Id);
+        return metadata;
+    }
+
+    private string? ReadActiveId()
+    {
+        var path = Path.Combine(_paths.BaseRootDirectory, ActiveFile);
+        if (!File.Exists(path))
+            return null;
+        try
+        {
+            using var document = JsonDocument.Parse(File.ReadAllText(path));
+            return document.RootElement.GetProperty("id").GetString();
+        }
+        catch (JsonException) { return null; }
+        catch (KeyNotFoundException) { return null; }
+        catch (InvalidOperationException) { return null; }
+    }
+
+    private async Task<WorkspaceMetadata?> ReadMetadataAsync(
+        string directory, string expectedId, CancellationToken cancellationToken)
+    {
+        var path = Path.Combine(directory, MetadataFile);
+        if (!File.Exists(path))
+            return null;
+        try
+        {
+            await using var stream = File.OpenRead(path);
+            var metadata = await JsonSerializer.DeserializeAsync<WorkspaceMetadata>(stream, _json, cancellationToken);
+            if (metadata is null || string.IsNullOrWhiteSpace(metadata.Id) ||
+                !metadata.Id.Equals(expectedId, StringComparison.Ordinal))
+                return null;
+            WorkspaceNameValidator.Validate(metadata.Id);
+            return metadata;
+        }
+        catch (JsonException) { return null; }
+        catch (UnauthorizedAccessException) { return null; }
+        catch (InvalidOperationException) { return null; }
+    }
+
+    private async Task WriteMetadataAsync(string directory, WorkspaceMetadata metadata, CancellationToken cancellationToken)
+    {
+        await File.WriteAllTextAsync(Path.Combine(directory, MetadataFile),
+            JsonSerializer.Serialize(metadata, _json), cancellationToken);
+    }
+
+    private string ResolveWorkspacePath(string id)
+    {
+        WorkspaceNameValidator.Validate(id);
+        var path = Path.GetFullPath(Path.Combine(_workspaceRoot, id));
+        if (!path.StartsWith(_workspaceRoot + Path.DirectorySeparatorChar, StringComparison.Ordinal))
+            throw new UnauthorizedAccessException("Workspace path escapes the data directory.");
+        if (Directory.Exists(path) &&
+            File.GetAttributes(path).HasFlag(FileAttributes.ReparsePoint))
+            throw new UnauthorizedAccessException("Workspace symlinks are not allowed.");
+        return path;
+    }
+
+    private void MigrateLegacyFiles(string destination)
+    {
+        foreach (var name in new[] { "appsettings.json", "conversation-history.json" })
+        {
+            var source = Path.Combine(_paths.BaseRootDirectory, name);
+            if (File.Exists(source) &&
+                !File.GetAttributes(source).HasFlag(FileAttributes.ReparsePoint))
+                File.Move(source, Path.Combine(destination, name));
+        }
+        var exports = Path.Combine(_paths.BaseRootDirectory, "exports");
+        if (Directory.Exists(exports) &&
+            !File.GetAttributes(exports).HasFlag(FileAttributes.ReparsePoint))
+            Directory.Move(exports, Path.Combine(destination, "exports"));
+        var conversations = Path.Combine(_paths.BaseRootDirectory, "conversations");
+        if (Directory.Exists(conversations) &&
+            !File.GetAttributes(conversations).HasFlag(FileAttributes.ReparsePoint))
+            Directory.Move(conversations, Path.Combine(destination, "conversations"));
+    }
+}
+
+public static class WorkspaceNameValidator
+{
+    public static void Validate(string id)
+    {
+        if (string.IsNullOrWhiteSpace(id) || id is "." or ".." ||
+            id.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0 ||
+            id.Contains('/') || id.Contains('\\'))
+            throw new UnauthorizedAccessException("Workspace identifiers must be safe directory names.");
+    }
+
+    public static string ToId(string name)
+    {
+        var id = new string(name.ToLowerInvariant().Select(c =>
+            char.IsLetterOrDigit(c) || c is '-' or '_' ? c : '-').ToArray()).Trim('-');
+        Validate(id);
+        return id;
+    }
+}

--- a/CoffeeTalk.Gui/Components/Pages/Home.razor
+++ b/CoffeeTalk.Gui/Components/Pages/Home.razor
@@ -11,6 +11,7 @@
 @inject NavigationManager Navigation
 @inject ConversationHistoryService History
 @inject IConversationSessionService Session
+@inject ISnackbar Snackbar
 
 
 <MudContainer MaxWidth="MaxWidth.Medium" Class="mt-8">
@@ -47,6 +48,18 @@
                     </MudItem>
                 </MudGrid>
             </MudPaper>
+            @if (AppState.CurrentWorkspace is not null)
+            {
+                <MudPaper Class="pa-4 mb-4" Outlined="true">
+                    <MudSelect T="string" Label="Workspace" Value="@AppState.CurrentWorkspace.Id"
+                               ValueChanged="SwitchWorkspace" Dense="true" Disabled="@Session.IsRunning">
+                        @foreach (var workspace in _workspaces)
+                        {
+                            <MudSelectItem Value="@workspace.Id">@workspace.Name</MudSelectItem>
+                        }
+                    </MudSelect>
+                </MudPaper>
+            }
             <MudCard Elevation="4" Class="pa-4">
                 <MudCardHeader>
                     <CardHeaderContent>
@@ -110,12 +123,14 @@
 
     private IReadOnlyCollection<object> SelectedPersonas { get; set; } = new List<object>();
     private IReadOnlyList<ConversationRecord> _recentConversations = Array.Empty<ConversationRecord>();
+    private IReadOnlyList<WorkspaceMetadata> _workspaces = Array.Empty<WorkspaceMetadata>();
 
     protected override void OnInitialized()
     {
         // Select all by default
         SelectedPersonas = AppState.Settings.Personas.Cast<object>().ToList();
         _recentConversations = History.Recent();
+        _workspaces = AppState.ListWorkspacesAsync().GetAwaiter().GetResult();
     }
 
     private void StartConversation()
@@ -131,5 +146,20 @@
     {
         await Session.LoadConversationAsync(conversation);
         Navigation.NavigateTo("/conversation");
+    }
+
+    private async Task SwitchWorkspace(string id)
+    {
+        if (id == AppState.CurrentWorkspace?.Id)
+            return;
+        if (Session.IsRunning)
+        {
+            Snackbar.Add("Stop the active conversation before switching workspaces.", Severity.Warning);
+            return;
+        }
+        await AppState.SwitchWorkspaceAsync(id);
+        _workspaces = await AppState.ListWorkspacesAsync();
+        SelectedPersonas = AppState.Settings.Personas.Cast<object>().ToList();
+        _recentConversations = await History.RecentAsync();
     }
 }

--- a/CoffeeTalk.Gui/Program.cs
+++ b/CoffeeTalk.Gui/Program.cs
@@ -15,7 +15,10 @@ class Program
         var appBuilder = PhotinoBlazorAppBuilder.CreateDefault(args);
 
         appBuilder.Services.AddLogging();
-        appBuilder.Services.AddSingleton<IApplicationDataPathResolver, ApplicationDataPathResolver>();
+        appBuilder.Services.AddSingleton<ApplicationDataPathResolver>();
+        appBuilder.Services.AddSingleton<IApplicationDataPathResolver>(sp => sp.GetRequiredService<ApplicationDataPathResolver>());
+        appBuilder.Services.AddSingleton<IWorkspacePathResolver>(sp => sp.GetRequiredService<ApplicationDataPathResolver>());
+        appBuilder.Services.AddSingleton<WorkspaceService>();
         appBuilder.Services.AddSingleton<IPdfDocumentExporter, PdfDocumentExporter>();
         appBuilder.Services.AddSingleton<ConfigurationService>();
         appBuilder.Services.AddSingleton<AppState>();

--- a/CoffeeTalk.Gui/Services/AppState.cs
+++ b/CoffeeTalk.Gui/Services/AppState.cs
@@ -6,14 +6,31 @@ namespace CoffeeTalk.Gui.Services;
 public class AppState
 {
     private readonly ConfigurationService _configService;
+    private readonly WorkspaceService? _workspaceService;
+    private readonly ApplicationDataPathResolver? _dataPaths;
 
     public AppSettings Settings { get; private set; } = new();
+    public WorkspaceMetadata? CurrentWorkspace => _workspaceService?.Active;
 
     public event Action? OnChange;
 
-    public AppState(ConfigurationService configService)
+    public AppState(ConfigurationService configService, WorkspaceService? workspaceService = null,
+        ApplicationDataPathResolver? dataPaths = null)
     {
         _configService = configService;
+        _workspaceService = workspaceService;
+        _dataPaths = dataPaths;
+        LoadSettings();
+    }
+
+    public Task<IReadOnlyList<WorkspaceMetadata>> ListWorkspacesAsync()
+        => _workspaceService?.ListAsync() ?? Task.FromResult<IReadOnlyList<WorkspaceMetadata>>(Array.Empty<WorkspaceMetadata>());
+
+    public async Task SwitchWorkspaceAsync(string id)
+    {
+        if (_workspaceService is null || _dataPaths is null)
+            throw new InvalidOperationException("Workspace management is unavailable.");
+        await _workspaceService.SwitchAsync(id);
         LoadSettings();
     }
 

--- a/CoffeeTalk.Gui/Services/ConversationSessionService.cs
+++ b/CoffeeTalk.Gui/Services/ConversationSessionService.cs
@@ -6,6 +6,7 @@ namespace CoffeeTalk.Gui.Services;
 
 public interface IConversationSessionService
 {
+    bool IsRunning { get; }
     void Start(string topic, IReadOnlyCollection<PersonaConfig> personas);
     void Cancel();
     Task LoadConversationAsync(ConversationRecord record);

--- a/CoffeeTalk.Tests/WorkspaceServiceTests.cs
+++ b/CoffeeTalk.Tests/WorkspaceServiceTests.cs
@@ -1,0 +1,84 @@
+using System.Text.Json;
+using CoffeeTalk.Models;
+using CoffeeTalk.Services;
+
+namespace CoffeeTalk.Tests;
+
+public sealed class WorkspaceServiceTests
+{
+    [Fact]
+    public async Task WorkspacesIsolateConfigurationAndConversationState()
+    {
+        var root = NewRoot();
+        var paths = new ApplicationDataPathResolver(root);
+        var workspaces = new WorkspaceService(paths);
+        var first = await workspaces.CreateAsync("Project Alpha");
+        await workspaces.SwitchAsync(first.Id);
+        await new ConfigurationService(paths).SaveSettingsAsync(new AppSettings { Personas = [new PersonaConfig { Name = "Alpha" }] });
+        await new ConversationPersistenceService(paths).SaveAsync(new ConversationState { Id = "alpha", Topic = "Alpha" });
+
+        var second = await workspaces.CreateAsync("Project Beta");
+        await workspaces.SwitchAsync(second.Id);
+
+        Assert.Empty(await new ConversationPersistenceService(paths).ListAsync());
+        Assert.Empty(new ConfigurationService(paths).LoadConfiguration().Personas);
+        Assert.Equal(second.Id, workspaces.Active.Id);
+        Assert.True(File.Exists(Path.Combine(root, "workspaces", first.Id, "conversations", "alpha.json")));
+    }
+
+    [Fact]
+    public async Task MigratesStandaloneFilesIntoDefaultWorkspace()
+    {
+        var root = NewRoot();
+        Directory.CreateDirectory(Path.Combine(root, "conversations"));
+        await File.WriteAllTextAsync(Path.Combine(root, "appsettings.json"), "{}");
+        await File.WriteAllTextAsync(Path.Combine(root, "conversations", "old.json"), "{}");
+
+        var workspaces = new WorkspaceService(new ApplicationDataPathResolver(root));
+
+        Assert.Equal("default", workspaces.Active.Id);
+        Assert.True(File.Exists(Path.Combine(root, "workspaces", "default", "appsettings.json")));
+        Assert.True(File.Exists(Path.Combine(root, "workspaces", "default", "conversations", "old.json")));
+        Assert.False(File.Exists(Path.Combine(root, "appsettings.json")));
+    }
+
+    [Theory]
+    [InlineData("../escape")]
+    [InlineData("folder/name")]
+    [InlineData("..")]
+    public void WorkspaceIdentifiersRejectTraversal(string id)
+    {
+        Assert.Throws<UnauthorizedAccessException>(() => WorkspaceNameValidator.Validate(id));
+    }
+
+    [Fact]
+    public async Task CorruptMetadataIsIgnoredAndDoesNotBecomeActive()
+    {
+        var root = NewRoot();
+        var workspaceRoot = Path.Combine(root, "workspaces", "broken");
+        Directory.CreateDirectory(workspaceRoot);
+        await File.WriteAllTextAsync(Path.Combine(workspaceRoot, "workspace.json"), "{");
+
+        var service = new WorkspaceService(new ApplicationDataPathResolver(root));
+
+        Assert.Equal("default", service.Active.Id);
+        Assert.DoesNotContain((await service.ListAsync()), item => item.Id == "broken");
+        using var active = JsonDocument.Parse(await File.ReadAllTextAsync(Path.Combine(root, "active-workspace.json")));
+        Assert.Equal("default", active.RootElement.GetProperty("id").GetString());
+    }
+
+    [Fact]
+    public async Task DeletingActiveWorkspaceSwitchesToAnotherWorkspace()
+    {
+        var service = new WorkspaceService(new ApplicationDataPathResolver(NewRoot()));
+        var created = await service.CreateAsync("Temporary");
+        await service.SwitchAsync(created.Id);
+
+        await service.DeleteAsync(created.Id);
+
+        Assert.Equal("default", service.Active.Id);
+        Assert.DoesNotContain((await service.ListAsync()), item => item.Id == created.Id);
+    }
+
+    private static string NewRoot() => Path.Combine(Path.GetTempPath(), "coffeetalk-tests", Guid.NewGuid().ToString("N"));
+}

--- a/CoffeeTalk/Program.cs
+++ b/CoffeeTalk/Program.cs
@@ -14,6 +14,10 @@ class Program
         try
         {
             var dataPaths = new ApplicationDataPathResolver();
+            var workspaces = new WorkspaceService(dataPaths);
+            if (await HandleWorkspaceCommandAsync(args, workspaces))
+                return;
+
             var persistence = new ConversationPersistenceService(dataPaths);
             if (await HandleHistoryCommandAsync(args, persistence))
                 return;
@@ -121,6 +125,46 @@ class Program
         }
 
         return false;
+    }
+
+    private static async Task<bool> HandleWorkspaceCommandAsync(string[] args, WorkspaceService workspaces)
+    {
+        var command = args.FirstOrDefault();
+        if (command is null || command.StartsWith("-", StringComparison.Ordinal))
+            return false;
+
+        switch (command.ToLowerInvariant())
+        {
+            case "list":
+                foreach (var workspace in await workspaces.ListAsync())
+                    AnsiConsole.MarkupLine($"{(workspace.Id == workspaces.Active.Id ? "[green]*[/]" : " ")} {Markup.Escape(workspace.Name)} ({Markup.Escape(workspace.Id)})");
+                return true;
+            case "new":
+                var name = GetOption(args, "--name")
+                    ?? throw new ArgumentException("The new command requires --name.");
+                var created = await workspaces.CreateAsync(name);
+                await workspaces.SwitchAsync(created.Id);
+                AnsiConsole.MarkupLine($"[green]Created and switched to workspace {Markup.Escape(created.Name)}[/]");
+                return true;
+            case "switch":
+                var switchName = args.Length > 1 && !args[1].StartsWith("-", StringComparison.Ordinal) ? args[1] : null;
+                if (string.IsNullOrWhiteSpace(switchName))
+                    throw new ArgumentException("The switch command requires a workspace name or id.");
+                var selected = await workspaces.SwitchAsync(switchName);
+                AnsiConsole.MarkupLine($"[green]Switched to workspace {Markup.Escape(selected.Name)}[/]");
+                return true;
+            case "delete":
+                var deleteName = args.Length > 1 && !args[1].StartsWith("-", StringComparison.Ordinal) ? args[1] : null;
+                if (string.IsNullOrWhiteSpace(deleteName))
+                    throw new ArgumentException("The delete command requires a workspace name or id.");
+                if (!AnsiConsole.Confirm($"Delete workspace '{Markup.Escape(deleteName)}' and all its conversations?", false))
+                    return true;
+                await workspaces.DeleteAsync(deleteName);
+                AnsiConsole.MarkupLine($"[green]Deleted workspace {Markup.Escape(deleteName)}[/]");
+                return true;
+            default:
+                return false;
+        }
     }
 
     private static string? GetOption(string[] args, string option)


### PR DESCRIPTION
Implements issue #46 with named workspace metadata, isolated configuration/conversation/export directories, standalone migration, CLI new/list/switch/delete commands, GUI workspace switching, traversal and reparse-point protection, corrupt metadata fallback, and focused tests.\n\nReviews: two independent read-only reviews completed; findings addressed.\n\nTests: dotnet test CoffeeTalk.Tests/CoffeeTalk.Tests.csproj --no-restore (80 passed).