### PR TITLE
Add local conversation analytics

### DIFF
--- a/CoffeeTalk.Core/Models/ConversationState.cs
+++ b/CoffeeTalk.Core/Models/ConversationState.cs
@@ -17,6 +17,7 @@ public sealed class ConversationState
     public DateTimeOffset? CompletedAt { get; set; }
     public string Status { get; set; } = "Completed";
     public Dictionary<string, string> Metadata { get; set; } = new(StringComparer.Ordinal);
+    public ConversationMetrics Metrics { get; set; } = new();
 }
 
 public sealed class ConversationMessage
@@ -34,4 +35,16 @@ public sealed class ConversationParticipant
     public string Name { get; set; } = string.Empty;
     public string? Role { get; set; }
     public Dictionary<string, string> Metadata { get; set; } = new(StringComparer.Ordinal);
+}
+
+public sealed class ConversationMetrics
+{
+    public TimeSpan Duration { get; set; }
+    public int MessageCount { get; set; }
+    public int WordCount { get; set; }
+    public int EstimatedTokenCount { get; set; }
+    public int DocumentWordCount { get; set; }
+    public int DocumentHeadingCount { get; set; }
+    public Dictionary<string, int> MessagesByParticipant { get; set; } = new(StringComparer.Ordinal);
+    public Dictionary<string, int> WordsByParticipant { get; set; } = new(StringComparer.Ordinal);
 }

--- a/CoffeeTalk.Core/Services/ConversationAnalyticsService.cs
+++ b/CoffeeTalk.Core/Services/ConversationAnalyticsService.cs
@@ -1,0 +1,87 @@
+using CoffeeTalk.Models;
+
+namespace CoffeeTalk.Services;
+
+public static class ConversationMetricsCalculator
+{
+    private const double ApproxCharsPerToken = 4.0;
+
+    public static ConversationMetrics Calculate(ConversationState state)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+
+        var messages = state.Messages.Where(message => !message.IsSystem && !message.IsDivider).ToList();
+        var metrics = new ConversationMetrics
+        {
+            Duration = state.CompletedAt.HasValue
+                ? state.CompletedAt.Value - state.StartedAt
+                : TimeSpan.Zero,
+            MessageCount = messages.Count,
+            DocumentWordCount = CountWords(state.DocumentContent),
+            DocumentHeadingCount = state.DocumentContent
+                .Split('\n')
+                .Count(line => line.TrimStart().StartsWith("#", StringComparison.Ordinal))
+        };
+
+        foreach (var message in messages)
+        {
+            var words = CountWords(message.Content);
+            metrics.WordCount += words;
+            metrics.EstimatedTokenCount += EstimateTokens(message.Content);
+            metrics.MessagesByParticipant[message.Sender] =
+                metrics.MessagesByParticipant.GetValueOrDefault(message.Sender) + 1;
+            metrics.WordsByParticipant[message.Sender] =
+                metrics.WordsByParticipant.GetValueOrDefault(message.Sender) + words;
+        }
+
+        if (metrics.Duration < TimeSpan.Zero)
+            metrics.Duration = TimeSpan.Zero;
+
+        return metrics;
+    }
+
+    private static int CountWords(string text) =>
+        string.IsNullOrWhiteSpace(text)
+            ? 0
+            : text.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries).Length;
+
+    private static int EstimateTokens(string text) =>
+        string.IsNullOrEmpty(text) ? 0 : Math.Max(1, (int)Math.Ceiling(text.Length / ApproxCharsPerToken));
+}
+
+public sealed class ConversationAnalyticsSummary
+{
+    public int ConversationCount { get; init; }
+    public int MessageCount { get; init; }
+    public int WordCount { get; init; }
+    public int EstimatedTokenCount { get; init; }
+    public TimeSpan AverageDuration { get; init; }
+    public IReadOnlyDictionary<string, int> MessagesByParticipant { get; init; } =
+        new Dictionary<string, int>(StringComparer.Ordinal);
+}
+
+public static class ConversationMetricsAggregator
+{
+    public static ConversationAnalyticsSummary Summarize(IEnumerable<ConversationState> states)
+    {
+        var items = states.ToList();
+        var participantCounts = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var state in items)
+        {
+            foreach (var pair in state.Metrics.MessagesByParticipant)
+                participantCounts[pair.Key] = participantCounts.GetValueOrDefault(pair.Key) + pair.Value;
+        }
+
+        return new ConversationAnalyticsSummary
+        {
+            ConversationCount = items.Count,
+            MessageCount = items.Sum(state => state.Metrics.MessageCount),
+            WordCount = items.Sum(state => state.Metrics.WordCount),
+            EstimatedTokenCount = items.Sum(state => state.Metrics.EstimatedTokenCount),
+            AverageDuration = items.Count == 0
+                ? TimeSpan.Zero
+                : TimeSpan.FromTicks(items.Sum(state => state.Metrics.Duration.Ticks) / items.Count),
+            MessagesByParticipant = participantCounts
+        };
+    }
+}

--- a/CoffeeTalk.Core/Services/ConversationPersistenceService.cs
+++ b/CoffeeTalk.Core/Services/ConversationPersistenceService.cs
@@ -37,6 +37,7 @@ public sealed class ConversationPersistenceService : IConversationPersistenceSer
         var id = NormalizeId(state.Id);
         state.Id = id;
         state.SchemaVersion = ConversationStateSchema.CurrentVersion;
+        state.Metrics = ConversationMetricsCalculator.Calculate(state);
         var path = PathFor(id);
         Directory.CreateDirectory(Path.GetDirectoryName(path)!);
         var temporary = path + "." + Guid.NewGuid().ToString("N") + ".tmp";
@@ -72,6 +73,7 @@ public sealed class ConversationPersistenceService : IConversationPersistenceSer
             state.Id = NormalizeId(state.Id);
             if (!state.Id.Equals(id, StringComparison.Ordinal))
                 throw new ConversationStateCorruptException("Conversation state identifier does not match its file.");
+            state.Metrics = ConversationMetricsCalculator.Calculate(state);
             return state;
         }
         catch (ConversationStateCorruptException) { throw; }

--- a/CoffeeTalk.Gui/Components/NavMenu.razor
+++ b/CoffeeTalk.Gui/Components/NavMenu.razor
@@ -4,5 +4,6 @@
 <MudNavMenu>
     <MudNavLink Href="/" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Home">Home</MudNavLink>
     <MudNavLink Href="/conversation" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Chat">Conversation</MudNavLink>
+    <MudNavLink Href="/analytics" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Analytics">Analytics</MudNavLink>
     <MudNavLink Href="/settings" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Settings">Settings</MudNavLink>
 </MudNavMenu>

--- a/CoffeeTalk.Gui/Components/Pages/Analytics.razor
+++ b/CoffeeTalk.Gui/Components/Pages/Analytics.razor
@@ -1,0 +1,54 @@
+@page "/analytics"
+@using CoffeeTalk.Gui.Services
+@using MudBlazor
+@inject ConversationHistoryService History
+
+<MudContainer MaxWidth="MaxWidth.Medium" Class="mt-8">
+    <MudText Typo="Typo.h2" GutterBottom="true">Conversation analytics</MudText>
+    <MudText Typo="Typo.body2" Color="Color.Secondary" Class="mb-4">
+        These statistics are calculated from locally saved conversations in the current workspace.
+        Token values are approximate character-based estimates; no provider pricing or prompt telemetry is collected.
+    </MudText>
+
+    <MudGrid>
+        <MudItem xs="6" sm="3"><MudPaper Class="pa-4"><MudText Typo="Typo.caption">Conversations</MudText><MudText Typo="Typo.h5">@_summary.ConversationCount</MudText></MudPaper></MudItem>
+        <MudItem xs="6" sm="3"><MudPaper Class="pa-4"><MudText Typo="Typo.caption">Messages</MudText><MudText Typo="Typo.h5">@_summary.MessageCount</MudText></MudPaper></MudItem>
+        <MudItem xs="6" sm="3"><MudPaper Class="pa-4"><MudText Typo="Typo.caption">Words</MudText><MudText Typo="Typo.h5">@_summary.WordCount</MudText></MudPaper></MudItem>
+        <MudItem xs="6" sm="3"><MudPaper Class="pa-4"><MudText Typo="Typo.caption">Estimated tokens</MudText><MudText Typo="Typo.h5">@_summary.EstimatedTokenCount</MudText></MudPaper></MudItem>
+    </MudGrid>
+
+    <MudPaper Class="pa-4 mt-4" Outlined="true">
+        <MudText Typo="Typo.subtitle1">Average duration</MudText>
+        <MudText Typo="Typo.h6">@FormatDuration(_summary.AverageDuration)</MudText>
+    </MudPaper>
+
+    <MudPaper Class="pa-4 mt-4" Outlined="true">
+        <MudText Typo="Typo.subtitle1" GutterBottom="true">Messages by participant</MudText>
+        @if (_summary.MessagesByParticipant.Count == 0)
+        {
+            <MudText Color="Color.Secondary">No saved conversation messages yet.</MudText>
+        }
+        else
+        {
+            @foreach (var participant in _summary.MessagesByParticipant.OrderByDescending(pair => pair.Value))
+            {
+                <div class="d-flex justify-space-between">
+                    <MudText>@participant.Key</MudText>
+                    <MudText Color="Color.Secondary">@participant.Value messages</MudText>
+                </div>
+            }
+        }
+    </MudPaper>
+</MudContainer>
+
+@code {
+    private ConversationAnalyticsSummary _summary = new();
+
+    protected override async Task OnInitializedAsync()
+        => _summary = await History.SummaryAsync();
+
+    private static string FormatDuration(TimeSpan duration) =>
+        duration.TotalHours >= 1
+            ? $"{(int)duration.TotalHours}h {duration.Minutes}m"
+            : $"{(int)duration.TotalMinutes}m {duration.Seconds}s";
+}

--- a/CoffeeTalk.Gui/Services/ConversationHistoryService.cs
+++ b/CoffeeTalk.Gui/Services/ConversationHistoryService.cs
@@ -26,6 +26,12 @@ public sealed class ConversationHistoryService
         return states.Take(count).Select(ToRecord).ToList();
     }
 
+    public async Task<IReadOnlyList<ConversationRecord>> AllAsync(CancellationToken cancellationToken = default)
+        => (await GetStatesAsync(cancellationToken)).Select(ToRecord).ToList();
+
+    public async Task<ConversationAnalyticsSummary> SummaryAsync(CancellationToken cancellationToken = default)
+        => ConversationMetricsAggregator.Summarize(await GetStatesAsync(cancellationToken));
+
     public Task<string> SaveAsync(ConversationRecord record, CancellationToken cancellationToken = default)
         => _persistence.SaveAsync(ToState(record), cancellationToken);
 
@@ -60,12 +66,19 @@ public sealed class ConversationHistoryService
                 await _persistence.SaveAsync(state, cancellationToken);
                 migrated.Add(state);
             }
+
             return migrated;
         }
         catch (JsonException ex)
         {
             throw new ConversationStateCorruptException("Legacy conversation history JSON is invalid.", ex);
         }
+    }
+
+    private async Task<IReadOnlyList<ConversationState>> GetStatesAsync(CancellationToken cancellationToken)
+    {
+        var states = await _persistence.ListAsync(cancellationToken);
+        return states.Count == 0 ? await MigrateLegacyAsync(cancellationToken) : states;
     }
 
     private static ConversationState ToState(ConversationRecord record) => new()
@@ -96,6 +109,7 @@ public sealed class ConversationHistoryService
         Personas = state.Participants.Select(participant => participant.Name).ToList(),
         DocumentContent = state.DocumentContent,
         Metadata = new Dictionary<string, string>(state.Metadata, StringComparer.Ordinal),
+        Metrics = state.Metrics,
         Messages = state.Messages.Select(message => new ChatMessage
         {
             Sender = message.Sender, Content = message.Content, IsSystem = message.IsSystem,

--- a/CoffeeTalk.Gui/Services/ConversationRecord.cs
+++ b/CoffeeTalk.Gui/Services/ConversationRecord.cs
@@ -1,3 +1,5 @@
+using CoffeeTalk.Models;
+
 namespace CoffeeTalk.Gui.Services;
 
 public sealed class ConversationRecord
@@ -12,4 +14,5 @@ public sealed class ConversationRecord
     public List<ChatMessage> Messages { get; set; } = new();
     public string DocumentContent { get; set; } = string.Empty;
     public Dictionary<string, string> Metadata { get; set; } = new(StringComparer.Ordinal);
+    public ConversationMetrics Metrics { get; set; } = new();
 }

--- a/CoffeeTalk.Tests/ConversationAnalyticsTests.cs
+++ b/CoffeeTalk.Tests/ConversationAnalyticsTests.cs
@@ -1,0 +1,69 @@
+using CoffeeTalk.Models;
+using CoffeeTalk.Services;
+
+namespace CoffeeTalk.Tests;
+
+public sealed class ConversationAnalyticsTests
+{
+    [Fact]
+    public void CalculateExcludesSystemAndDividerMessagesAndTracksParticipants()
+    {
+        var state = new ConversationState
+        {
+            StartedAt = DateTimeOffset.UtcNow.AddMinutes(-2),
+            CompletedAt = DateTimeOffset.UtcNow,
+            DocumentContent = "# Summary\nA recommendation",
+            Messages =
+            [
+                new() { Sender = "System", Content = "hidden", IsSystem = true },
+                new() { Sender = "Alice", Content = "One two." },
+                new() { Sender = "Bob", Content = "Three", IsDivider = true },
+                new() { Sender = "Alice", Content = "Four five." }
+            ]
+        };
+
+        var metrics = ConversationMetricsCalculator.Calculate(state);
+
+        Assert.Equal(2, metrics.MessageCount);
+        Assert.Equal(4, metrics.WordCount);
+        Assert.Equal(2, metrics.MessagesByParticipant["Alice"]);
+        Assert.Equal(4, metrics.WordsByParticipant["Alice"]);
+        Assert.Equal(5, metrics.EstimatedTokenCount);
+        Assert.Equal(4, metrics.DocumentWordCount);
+        Assert.Equal(1, metrics.DocumentHeadingCount);
+        Assert.InRange(metrics.Duration, TimeSpan.FromMinutes(1.9), TimeSpan.FromMinutes(2.1));
+    }
+
+    [Fact]
+    public void SummarizeAggregatesSavedConversationMetrics()
+    {
+        var first = new ConversationState
+        {
+            Metrics = new ConversationMetrics
+            {
+                MessageCount = 2, WordCount = 10, EstimatedTokenCount = 4,
+                Duration = TimeSpan.FromMinutes(2),
+                MessagesByParticipant = new() { ["Alice"] = 2 }
+            }
+        };
+        var second = new ConversationState
+        {
+            Metrics = new ConversationMetrics
+            {
+                MessageCount = 1, WordCount = 5, EstimatedTokenCount = 2,
+                Duration = TimeSpan.FromMinutes(4),
+                MessagesByParticipant = new() { ["Bob"] = 1 }
+            }
+        };
+
+        var summary = ConversationMetricsAggregator.Summarize([first, second]);
+
+        Assert.Equal(2, summary.ConversationCount);
+        Assert.Equal(3, summary.MessageCount);
+        Assert.Equal(15, summary.WordCount);
+        Assert.Equal(6, summary.EstimatedTokenCount);
+        Assert.Equal(TimeSpan.FromMinutes(3), summary.AverageDuration);
+        Assert.Equal(2, summary.MessagesByParticipant["Alice"]);
+        Assert.Equal(1, summary.MessagesByParticipant["Bob"]);
+    }
+}

--- a/CoffeeTalk.Tests/ConversationPersistenceServiceTests.cs
+++ b/CoffeeTalk.Tests/ConversationPersistenceServiceTests.cs
@@ -29,6 +29,8 @@ public sealed class ConversationPersistenceServiceTests
         Assert.Equal(state.DocumentContent, restored.DocumentContent);
         Assert.Equal("Engineer", restored.Participants[0].Name);
         Assert.Equal("test", restored.Metadata["source"]);
+        Assert.Equal(1, restored.Metrics.MessageCount);
+        Assert.Equal(1, restored.Metrics.WordCount);
     }
 
     [Fact]
@@ -69,6 +71,34 @@ public sealed class ConversationPersistenceServiceTests
         await service.DeleteAsync("one");
         Assert.Single(await service.ListAsync());
         await Assert.ThrowsAsync<FileNotFoundException>(() => service.ResumeAsync("one"));
+    }
+
+    [Fact]
+    public async Task ResumeCalculatesMetricsForOlderStatesWithoutMetrics()
+    {
+        var root = NewRoot();
+        var resolver = new ApplicationDataPathResolver(root);
+        var service = new ConversationPersistenceService(resolver);
+        var path = resolver.ResolveDataPath("conversations/legacy.json", "conversation.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        await File.WriteAllTextAsync(path, """
+            {
+              "schemaVersion": 1,
+              "id": "legacy",
+              "topic": "Legacy",
+              "startedAt": "2026-01-01T00:00:00Z",
+              "messages": [
+                { "sender": "Alice", "content": "Hello there", "timestamp": "2026-01-01T00:00:01Z" }
+              ],
+              "participants": [],
+              "metadata": {}
+            }
+            """);
+
+        var restored = await service.ResumeAsync("legacy");
+
+        Assert.Equal(1, restored.Metrics.MessageCount);
+        Assert.Equal(2, restored.Metrics.WordCount);
     }
 
     private static string NewRoot() => Path.Combine(Path.GetTempPath(), "coffeetalk-tests", Guid.NewGuid().ToString("N"));

--- a/CoffeeTalk/Program.cs
+++ b/CoffeeTalk/Program.cs
@@ -19,6 +19,8 @@ class Program
                 return;
 
             var persistence = new ConversationPersistenceService(dataPaths);
+            if (await HandleAnalyticsCommandAsync(args, persistence))
+                return;
             if (await HandleHistoryCommandAsync(args, persistence))
                 return;
 
@@ -126,6 +128,52 @@ class Program
 
         return false;
     }
+
+    private static async Task<bool> HandleAnalyticsCommandAsync(
+        string[] args, ConversationPersistenceService persistence)
+    {
+        if (!string.Equals(args.FirstOrDefault(), "stats", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var sessionId = GetOption(args, "--session");
+        if (sessionId is not null)
+        {
+            var state = await persistence.ResumeAsync(sessionId);
+            PrintMetrics(state.Topic, state.Metrics);
+            return true;
+        }
+
+        var summary = ConversationMetricsAggregator.Summarize(await persistence.ListAsync());
+        AnsiConsole.MarkupLine($"[bold]Conversations:[/] {summary.ConversationCount}");
+        AnsiConsole.MarkupLine($"[bold]Messages:[/] {summary.MessageCount}");
+        AnsiConsole.MarkupLine($"[bold]Words:[/] {summary.WordCount}");
+        AnsiConsole.MarkupLine($"[bold]Estimated tokens:[/] {summary.EstimatedTokenCount} (local approximation)");
+        AnsiConsole.MarkupLine($"[bold]Average duration:[/] {FormatDuration(summary.AverageDuration)}");
+        if (summary.MessagesByParticipant.Count > 0)
+        {
+            AnsiConsole.MarkupLine("[bold]Messages by participant:[/]");
+            foreach (var participant in summary.MessagesByParticipant.OrderByDescending(pair => pair.Value))
+                AnsiConsole.MarkupLine($"  {Markup.Escape(participant.Key)}: {participant.Value}");
+        }
+        return true;
+    }
+
+    private static void PrintMetrics(string topic, ConversationMetrics metrics)
+    {
+        AnsiConsole.MarkupLine($"[bold]Topic:[/] {Markup.Escape(topic)}");
+        AnsiConsole.MarkupLine($"[bold]Messages:[/] {metrics.MessageCount}");
+        AnsiConsole.MarkupLine($"[bold]Words:[/] {metrics.WordCount}");
+        AnsiConsole.MarkupLine($"[bold]Estimated tokens:[/] {metrics.EstimatedTokenCount} (local approximation)");
+        AnsiConsole.MarkupLine($"[bold]Duration:[/] {FormatDuration(metrics.Duration)}");
+        AnsiConsole.MarkupLine($"[bold]Document:[/] {metrics.DocumentWordCount} words, {metrics.DocumentHeadingCount} headings");
+        foreach (var participant in metrics.MessagesByParticipant.OrderByDescending(pair => pair.Value))
+            AnsiConsole.MarkupLine($"  {Markup.Escape(participant.Key)}: {participant.Value} messages, {metrics.WordsByParticipant.GetValueOrDefault(participant.Key)} words");
+    }
+
+    private static string FormatDuration(TimeSpan duration) =>
+        duration.TotalHours >= 1
+            ? $"{(int)duration.TotalHours}h {duration.Minutes}m"
+            : $"{(int)duration.TotalMinutes}m {duration.Seconds}s";
 
     private static async Task<bool> HandleWorkspaceCommandAsync(string[] args, WorkspaceService workspaces)
     {

--- a/USAGE.md
+++ b/USAGE.md
@@ -314,3 +314,13 @@ Thank you for using CoffeeTalk! ☕
 - Integrate with your workflow or tools
 
 For more information, see the main [README.md](README.md).
+# Analytics
+
+Conversation statistics are stored with each conversation inside the active workspace. The GUI exposes them at **Analytics**, and the CLI can print aggregate or per-conversation summaries:
+
+```bash
+dotnet run --project CoffeeTalk -- stats
+dotnet run --project CoffeeTalk -- stats --session <conversation-id>
+```
+
+Metrics are derived locally from saved message metadata: conversation/message/word counts, approximate character-based token estimates, duration, participant message and word counts, and document word/heading counts. CoffeeTalk does not calculate provider costs or collect additional prompt telemetry for analytics.


### PR DESCRIPTION
## Summary
- persist workspace-scoped local conversation metrics with backward-compatible recalculation
- add GUI analytics dashboard and CLI  /  reports
- document privacy boundaries and add focused persistence/aggregation tests

Metrics are limited to local counts, durations, participant balance, document structure, and approximate character-based token estimates. No provider cost accounting or additional prompt telemetry is collected.

## Validation
-   Determining projects to restore...
  All projects are up-to-date for restore.
  CoffeeTalk.Core -> /Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-redesigned-invention/CoffeeTalk.Core/bin/Debug/net9.0/CoffeeTalk.Core.dll
/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-redesigned-invention/CoffeeTalk.Gui/Components/Pages/Conversation.razor(279,22): warning CS0618: 'IDialogService.Show<TComponent>(string?, DialogParameters)' is obsolete: 'Use ShowAsync instead. This will be removed in future major version.' [/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-redesigned-invention/CoffeeTalk.Gui/CoffeeTalk.Gui.csproj]
/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-redesigned-invention/CoffeeTalk.Gui/Components/Pages/Conversation.razor(281,14): warning CS8602: Dereference of a possibly null reference. [/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-redesigned-invention/CoffeeTalk.Gui/CoffeeTalk.Gui.csproj]
/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-redesigned-invention/CoffeeTalk.Gui/Components/Pages/Conversation.razor(293,20): warning CS0219: The variable 'mimeType' is assigned but its value is never used [/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-redesigned-invention/CoffeeTalk.Gui/CoffeeTalk.Gui.csproj]
/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-redesigned-invention/CoffeeTalk.Gui/Components/Pages/Settings.razor(144,22): warning CS0618: 'IDialogService.Show<TComponent>(string?, DialogParameters)' is obsolete: 'Use ShowAsync instead. This will be removed in future major version.' [/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-redesigned-invention/CoffeeTalk.Gui/CoffeeTalk.Gui.csproj]
/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-redesigned-invention/CoffeeTalk.Gui/Components/Pages/Settings.razor(147,14): warning CS8602: Dereference of a possibly null reference. [/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-redesigned-invention/CoffeeTalk.Gui/CoffeeTalk.Gui.csproj]
/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-redesigned-invention/CoffeeTalk.Gui/Components/Pages/Settings.razor(149,33): warning CS8600: Converting null literal or possible null value to non-nullable type. [/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-redesigned-invention/CoffeeTalk.Gui/CoffeeTalk.Gui.csproj]
/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-redesigned-invention/CoffeeTalk.Gui/Components/Pages/Settings.razor(149,33): warning CS8604: Possible null reference argument for parameter 'persona' in 'void AppState.AddPersona(PersonaConfig persona)'. [/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-redesigned-invention/CoffeeTalk.Gui/CoffeeTalk.Gui.csproj]
/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-redesigned-invention/CoffeeTalk.Gui/Components/Pages/Settings.razor(164,22): warning CS0618: 'IDialogService.Show<TComponent>(string?, DialogParameters)' is obsolete: 'Use ShowAsync instead. This will be removed in future major version.' [/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-redesigned-invention/CoffeeTalk.Gui/CoffeeTalk.Gui.csproj]
/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-redesigned-invention/CoffeeTalk.Gui/Components/Pages/Settings.razor(167,14): warning CS8602: Dereference of a possibly null reference. [/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-redesigned-invention/CoffeeTalk.Gui/CoffeeTalk.Gui.csproj]
/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-redesigned-invention/CoffeeTalk.Gui/Components/Pages/Settings.razor(169,45): warning CS8600: Converting null literal or possible null value to non-nullable type. [/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-redesigned-invention/CoffeeTalk.Gui/CoffeeTalk.Gui.csproj]
/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-redesigned-invention/CoffeeTalk.Gui/Components/Pages/Settings.razor(169,45): warning CS8604: Possible null reference argument for parameter 'updatedPersona' in 'void AppState.UpdatePersona(PersonaConfig existingPersona, PersonaConfig updatedPersona)'. [/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-redesigned-invention/CoffeeTalk.Gui/CoffeeTalk.Gui.csproj]
/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-redesigned-invention/CoffeeTalk.Gui/Components/Pages/Conversation.razor(149,21): warning CS0649: Field 'Conversation._exportFormat' is never assigned to, and will always have its default value null [/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-redesigned-invention/CoffeeTalk.Gui/CoffeeTalk.Gui.csproj]
/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-redesigned-invention/CoffeeTalk.Gui/Components/ExportDialog.razor(1,1): warning MUD0002: Illegal Attribute 'Orientation' on 'MudRadioGroup' using pattern 'LowerCase' source location '(264,8)-(264,70)' (https://mudblazor.com/features/analyzers) [/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-redesigned-invention/CoffeeTalk.Gui/CoffeeTalk.Gui.csproj]
/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-redesigned-invention/CoffeeTalk.Gui/Components/MainLayout.razor(1,1): warning MUD0002: Illegal Attribute 'Link' on 'MudIconButton' using pattern 'LowerCase' source location '(401,20)-(401,103)' (https://mudblazor.com/features/analyzers) [/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-redesigned-invention/CoffeeTalk.Gui/CoffeeTalk.Gui.csproj]
/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-redesigned-invention/CoffeeTalk.Gui/Components/Pages/Conversation.razor(1,1): warning MUD0002: Illegal Attribute 'Title' on 'MudIconButton' using pattern 'LowerCase' source location '(1048,28)-(1048,87)' (https://mudblazor.com/features/analyzers) [/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-redesigned-invention/CoffeeTalk.Gui/CoffeeTalk.Gui.csproj]
/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-redesigned-invention/CoffeeTalk.Gui/Components/Pages/Home.razor(1,1): warning MUD0002: Illegal Attribute 'MultiSelection' on 'MudChipSet' using pattern 'LowerCase' source location '(1467,36)-(1467,99)' (https://mudblazor.com/features/analyzers) [/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-redesigned-invention/CoffeeTalk.Gui/CoffeeTalk.Gui.csproj]
/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-redesigned-invention/CoffeeTalk.Gui/Components/Pages/Settings.razor(1,1): warning MUD0002: Illegal Attribute 'Nullable' on 'MudNumericField' using pattern 'LowerCase' source location '(2431,8)-(2431,67)' (https://mudblazor.com/features/analyzers) [/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-redesigned-invention/CoffeeTalk.Gui/CoffeeTalk.Gui.csproj]
/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-redesigned-invention/CoffeeTalk.Gui/Components/Pages/Settings.razor(1,1): warning MUD0002: Illegal Attribute 'Nullable' on 'MudNumericField' using pattern 'LowerCase' source location '(2456,8)-(2456,67)' (https://mudblazor.com/features/analyzers) [/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-redesigned-invention/CoffeeTalk.Gui/CoffeeTalk.Gui.csproj]
  CoffeeTalk.Gui -> /Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-redesigned-invention/CoffeeTalk.Gui/bin/Debug/net9.0/CoffeeTalk.Gui.dll
/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-redesigned-invention/CoffeeTalk.Tests/ConversationComponentTests.cs(15,43): warning CS0618: 'TestContext' is obsolete: 'Use BunitContext instead. TestContext will be removed in a future release.' (https://bunit.dev/docs/migrations) [/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-redesigned-invention/CoffeeTalk.Tests/CoffeeTalk.Tests.csproj]
/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-redesigned-invention/CoffeeTalk.Tests/ConversationComponentTests.cs(17,113): warning CS0618: 'TestContext' is obsolete: 'Use BunitContext instead. TestContext will be removed in a future release.' (https://bunit.dev/docs/migrations) [/Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-redesigned-invention/CoffeeTalk.Tests/CoffeeTalk.Tests.csproj]
  CoffeeTalk.Tests -> /Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-redesigned-invention/CoffeeTalk.Tests/bin/Debug/net9.0/CoffeeTalk.Tests.dll
Test run for /Users/chrismalpasspersonal/repos/copilot-worktrees/coffeetalk/cmalpass-redesigned-invention/CoffeeTalk.Tests/bin/Debug/net9.0/CoffeeTalk.Tests.dll (.NETCoreApp,Version=v9.0)
VSTest version 18.0.1 (arm64)

Starting test execution, please wait...
A total of 1 test files matched the specified pattern.

Passed!  - Failed:     0, Passed:    86, Skipped:     0, Total:    86, Duration: 170 ms - CoffeeTalk.Tests.dll (net9.0) (86 passed)
- Two independent read-only code reviews completed