### PR TITLE
Fix follow-up backlog validation defects

### DIFF
--- a/CoffeeTalk.Core/Services/AgentPersona.cs
+++ b/CoffeeTalk.Core/Services/AgentPersona.cs
@@ -164,6 +164,7 @@ public class AgentPersona
                 continue;
 
             emitted = true;
+            _rateLimiter?.AccountAdditionalTokens(_rateLimiter.EstimateTokens(text));
             yield return text;
         }
 

--- a/CoffeeTalk.Core/Services/ApplicationDataPathResolver.cs
+++ b/CoffeeTalk.Core/Services/ApplicationDataPathResolver.cs
@@ -76,7 +76,8 @@ public sealed class ApplicationDataPathResolver : IWorkspacePathResolver
                      .Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries))
         {
             current = Path.Combine(current, segment);
-            if (Directory.Exists(current) && File.GetAttributes(current).HasFlag(FileAttributes.ReparsePoint))
+            if ((Directory.Exists(current) || File.Exists(current)) &&
+                File.GetAttributes(current).HasFlag(FileAttributes.ReparsePoint))
                 throw new UnauthorizedAccessException("Reparse points are not allowed in the data directory.");
         }
         return fullPath;

--- a/CoffeeTalk.Gui/Services/ConversationHistoryService.cs
+++ b/CoffeeTalk.Gui/Services/ConversationHistoryService.cs
@@ -20,9 +20,8 @@ public sealed class ConversationHistoryService
 
     public async Task<IReadOnlyList<ConversationRecord>> RecentAsync(int count = 10, CancellationToken cancellationToken = default)
     {
+        await MigrateLegacyAsync(cancellationToken);
         var states = await _persistence.ListAsync(cancellationToken);
-        if (states.Count == 0)
-            states = await MigrateLegacyAsync(cancellationToken);
         return states.Take(count).Select(ToRecord).ToList();
     }
 
@@ -77,8 +76,8 @@ public sealed class ConversationHistoryService
 
     private async Task<IReadOnlyList<ConversationState>> GetStatesAsync(CancellationToken cancellationToken)
     {
-        var states = await _persistence.ListAsync(cancellationToken);
-        return states.Count == 0 ? await MigrateLegacyAsync(cancellationToken) : states;
+        await MigrateLegacyAsync(cancellationToken);
+        return await _persistence.ListAsync(cancellationToken);
     }
 
     private static ConversationState ToState(ConversationRecord record) => new()

--- a/CoffeeTalk.Tests/ConversationHistoryServiceTests.cs
+++ b/CoffeeTalk.Tests/ConversationHistoryServiceTests.cs
@@ -1,0 +1,49 @@
+using System.Text.Json;
+using CoffeeTalk.Gui.Services;
+using CoffeeTalk.Models;
+using CoffeeTalk.Services;
+
+namespace CoffeeTalk.Tests;
+
+public sealed class ConversationHistoryServiceTests
+{
+    [Fact]
+    public async Task RecentMigratesLegacyHistoryAlongsideExistingConversations()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "coffeetalk-tests", Guid.NewGuid().ToString("N"));
+        var resolver = new ApplicationDataPathResolver(root);
+        var persistence = new ConversationPersistenceService(resolver);
+        var legacyPath = resolver.ResolveDataPath("conversation-history.json", "conversation-history.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(legacyPath)!);
+        try
+        {
+            await persistence.SaveAsync(new ConversationState
+            {
+                Id = "existing",
+                Topic = "Existing",
+                StartedAt = DateTimeOffset.UtcNow.AddMinutes(1)
+            });
+            await File.WriteAllTextAsync(legacyPath, JsonSerializer.Serialize(new[]
+            {
+                new ConversationRecord
+                {
+                    Id = "legacy",
+                    Topic = "Legacy",
+                    StartedAt = DateTime.UtcNow
+                }
+            }));
+
+            var history = new ConversationHistoryService(resolver);
+
+            var records = await history.RecentAsync();
+
+            Assert.Equal(2, records.Count);
+            Assert.Contains(records, record => record.Id == "legacy");
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+}

--- a/CoffeeTalk.Tests/ConversationPersistenceServiceTests.cs
+++ b/CoffeeTalk.Tests/ConversationPersistenceServiceTests.cs
@@ -101,5 +101,30 @@ public sealed class ConversationPersistenceServiceTests
         Assert.Equal(2, restored.Metrics.WordCount);
     }
 
+    [Fact]
+    public async Task ResumeRejectsSymlinkedConversationFile()
+    {
+        var root = NewRoot();
+        var resolver = new ApplicationDataPathResolver(root);
+        var service = new ConversationPersistenceService(resolver);
+        var outside = Path.Combine(Path.GetTempPath(), $"coffeetalk-outside-{Guid.NewGuid():N}.json");
+        var link = resolver.ResolveDataPath("conversations/linked.json", "conversation.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(link)!);
+        try
+        {
+            await File.WriteAllTextAsync(outside, "{}");
+            File.CreateSymbolicLink(link, outside);
+
+            await Assert.ThrowsAsync<UnauthorizedAccessException>(() => service.ResumeAsync("linked"));
+        }
+        finally
+        {
+            if (File.Exists(link))
+                File.Delete(link);
+            if (File.Exists(outside))
+                File.Delete(outside);
+        }
+    }
+
     private static string NewRoot() => Path.Combine(Path.GetTempPath(), "coffeetalk-tests", Guid.NewGuid().ToString("N"));
 }


### PR DESCRIPTION
Fixes three defects found during final integrated validation after PR #111: account streamed response chunks against rate limits, migrate legacy conversation history even when new records exist, and reject symlinked conversation files. Adds regression coverage for migration and symlink rejection.