### PR TITLE
Close remaining validation findings

### DIFF
--- a/CoffeeTalk.Core/Services/ConfigurationService.cs
+++ b/CoffeeTalk.Core/Services/ConfigurationService.cs
@@ -28,6 +28,15 @@ public class ConfigurationService
 
         var settings = new AppSettings();
         configuration.Bind(settings);
+        if (string.IsNullOrWhiteSpace(settings.LlmProvider.ApiKey))
+        {
+            settings.LlmProvider.ApiKey = settings.LlmProvider.Type.ToLowerInvariant() switch
+            {
+                "openai" => Environment.GetEnvironmentVariable("OPENAI_API_KEY") ?? string.Empty,
+                "azureopenai" => Environment.GetEnvironmentVariable("AZURE_OPENAI_API_KEY") ?? string.Empty,
+                _ => string.Empty
+            };
+        }
 
         return settings;
     }

--- a/CoffeeTalk.Core/Services/RateLimiter.cs
+++ b/CoffeeTalk.Core/Services/RateLimiter.cs
@@ -116,6 +116,10 @@ public class RateLimiter
             RollWindow();
             _tokensInWindow += Math.Max(0, tokens);
             _convTokens += Math.Max(0, tokens);
+            if (_cfg.TokensPerMinute.HasValue && _tokensInWindow > _cfg.TokensPerMinute.Value)
+            {
+                throw new InvalidOperationException($"Per-minute token cap reached ({_cfg.TokensPerMinute})");
+            }
             if (_cfg.MaxTokensPerConversation.HasValue && _convTokens > _cfg.MaxTokensPerConversation.Value)
             {
                 throw new InvalidOperationException($"Conversation token cap reached ({_cfg.MaxTokensPerConversation})");

--- a/CoffeeTalk.Gui/Services/ConversationHistoryService.cs
+++ b/CoffeeTalk.Gui/Services/ConversationHistoryService.cs
@@ -66,6 +66,7 @@ public sealed class ConversationHistoryService
                 migrated.Add(state);
             }
 
+            File.Delete(path);
             return migrated;
         }
         catch (JsonException ex)

--- a/CoffeeTalk.Tests/ConfigurationServiceTests.cs
+++ b/CoffeeTalk.Tests/ConfigurationServiceTests.cs
@@ -49,4 +49,23 @@ public sealed class ConfigurationServiceTests
         Assert.Null(loaded.Tools);
         Assert.Null(loaded.Orchestrator);
     }
+
+    [Fact]
+    public void LoadConfiguration_UsesProviderEnvironmentApiKeyWhenUnset()
+    {
+        const string variable = "OPENAI_API_KEY";
+        var original = Environment.GetEnvironmentVariable(variable);
+        var root = Path.Combine(Path.GetTempPath(), "coffeetalk-tests", Guid.NewGuid().ToString("N"));
+        try
+        {
+            Environment.SetEnvironmentVariable(variable, "test-key");
+            var service = new ConfigurationService(new ApplicationDataPathResolver(root));
+
+            Assert.Equal("test-key", service.LoadConfiguration().LlmProvider.ApiKey);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(variable, original);
+        }
+    }
 }

--- a/CoffeeTalk.Tests/ConversationHistoryServiceTests.cs
+++ b/CoffeeTalk.Tests/ConversationHistoryServiceTests.cs
@@ -39,6 +39,10 @@ public sealed class ConversationHistoryServiceTests
 
             Assert.Equal(2, records.Count);
             Assert.Contains(records, record => record.Id == "legacy");
+
+            await history.DeleteAsync("legacy");
+
+            Assert.DoesNotContain(await history.AllAsync(), record => record.Id == "legacy");
         }
         finally
         {

--- a/CoffeeTalk.Tests/RateLimiterTests.cs
+++ b/CoffeeTalk.Tests/RateLimiterTests.cs
@@ -53,4 +53,14 @@ public sealed class RateLimiterTests
         Assert.Equal(2, limiter.EstimateTokens("abc"));
         Assert.Equal(0, limiter.EstimateTokens(string.Empty));
     }
+
+    [Fact]
+    public async Task AccountAdditionalTokens_EnforcesPerMinuteTokenCap()
+    {
+        var limiter = new RateLimiter(new RateLimitConfig { TokensPerMinute = 3 });
+
+        await limiter.ThrottleAsync(2);
+
+        Assert.Throws<InvalidOperationException>(() => limiter.AccountAdditionalTokens(2));
+    }
 }


### PR DESCRIPTION
Fixes remaining findings from final cumulative reviews: preserve legacy migration deletion semantics, enforce per-minute token caps during streaming accounting, and restore documented OpenAI/Azure API-key environment fallbacks in GUI configuration with regression tests.