### PR TITLE
Complete streaming retry accounting

### DIFF
--- a/CoffeeTalk.Core/Services/AgentFactChecker.cs
+++ b/CoffeeTalk.Core/Services/AgentFactChecker.cs
@@ -61,6 +61,7 @@ Output Format:
                 cancellationToken);
 
             var result = response.ToString().Trim();
+            _rateLimiter?.AccountAdditionalTokens(_rateLimiter.EstimateTokens(result));
 
             if (!result.StartsWith("PASS", StringComparison.OrdinalIgnoreCase))
             {

--- a/CoffeeTalk.Core/Services/AgentPersona.cs
+++ b/CoffeeTalk.Core/Services/AgentPersona.cs
@@ -149,7 +149,10 @@ public class AgentPersona
             bool hasUpdate;
             try
             {
-                hasUpdate = await updates.MoveNextAsync();
+                hasUpdate = await _retryService.ExecuteAsync(
+                    _ => updates.MoveNextAsync().AsTask(),
+                    $"{Name} streaming response chunk",
+                    cancellationToken);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Retry streamed chunk advancement through the configured retry policy and account fact-check responses against shared rate limits.