### PR TITLE
Fix final validation findings

### DIFF
--- a/CoffeeTalk.Core/Services/AgentPersona.cs
+++ b/CoffeeTalk.Core/Services/AgentPersona.cs
@@ -139,38 +139,59 @@ public class AgentPersona
 
         var emitted = false;
         Exception? failure = null;
-        await using var updates = await _retryService.ExecuteAsync(
-            token => Task.FromResult(_agent.RunStreamingAsync(contextMessage, cancellationToken: token)
-                .GetAsyncEnumerator(token)),
-            $"{Name} streaming response",
-            cancellationToken);
-        while (true)
+        IAsyncEnumerator<AgentRunResponseUpdate>? updates = null;
+        try
         {
-            bool hasUpdate;
-            try
+            var initialUpdate = await _retryService.ExecuteAsync(
+                async token =>
+                {
+                    var enumerator = _agent
+                        .RunStreamingAsync(contextMessage, cancellationToken: token)
+                        .GetAsyncEnumerator(token);
+                    try
+                    {
+                        return (enumerator: enumerator, hasUpdate: await enumerator.MoveNextAsync());
+                    }
+                    catch
+                    {
+                        await enumerator.DisposeAsync();
+                        throw;
+                    }
+                },
+                $"{Name} streaming response",
+                cancellationToken);
+            updates = initialUpdate.enumerator;
+            var hasUpdate = initialUpdate.hasUpdate;
+
+            while (hasUpdate)
             {
-                hasUpdate = await _retryService.ExecuteAsync(
-                    _ => updates.MoveNextAsync().AsTask(),
-                    $"{Name} streaming response chunk",
-                    cancellationToken);
+                cancellationToken.ThrowIfCancellationRequested();
+                var text = updates.Current.Text;
+                if (!string.IsNullOrEmpty(text))
+                {
+                    emitted = true;
+                    _rateLimiter?.AccountAdditionalTokens(_rateLimiter.EstimateTokens(text));
+                    yield return text;
+                }
+
+                try
+                {
+                    hasUpdate = await _retryService.ExecuteAsync(
+                        _ => updates.MoveNextAsync().AsTask(),
+                        $"{Name} streaming response chunk",
+                        cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    failure = ex;
+                    break;
+                }
             }
-            catch (Exception ex)
-            {
-                failure = ex;
-                break;
-            }
-
-            if (!hasUpdate)
-                break;
-
-            cancellationToken.ThrowIfCancellationRequested();
-            var text = updates.Current.Text;
-            if (string.IsNullOrEmpty(text))
-                continue;
-
-            emitted = true;
-            _rateLimiter?.AccountAdditionalTokens(_rateLimiter.EstimateTokens(text));
-            yield return text;
+        }
+        finally
+        {
+            if (updates is not null)
+                await updates.DisposeAsync();
         }
 
         if (failure is OperationCanceledException)

--- a/CoffeeTalk.Gui/Services/ConversationSessionService.cs
+++ b/CoffeeTalk.Gui/Services/ConversationSessionService.cs
@@ -107,6 +107,7 @@ public sealed class ConversationSessionService : IConversationSessionService, ID
         if (previousTask is not null)
             await previousTask.ConfigureAwait(false);
 
+        cts.Token.ThrowIfCancellationRequested();
         _ui.ResetForNewConversation();
         await RunAsync(topic, personas, cts);
     }


### PR DESCRIPTION
Addresses final cumulative review findings after PR #117: cancelled queued GUI conversations now stop before starting, and streaming retries recreate the provider enumerator when the initial request fails during MoveNextAsync. Validation: 90 Release tests passed; Release build succeeded.