### PR TITLE
Harden final validation fixes

### DIFF
--- a/CoffeeTalk.Core/Services/AgentPersona.cs
+++ b/CoffeeTalk.Core/Services/AgentPersona.cs
@@ -176,10 +176,7 @@ public class AgentPersona
 
                 try
                 {
-                    hasUpdate = await _retryService.ExecuteAsync(
-                        _ => updates.MoveNextAsync().AsTask(),
-                        $"{Name} streaming response chunk",
-                        cancellationToken);
+                    hasUpdate = await updates.MoveNextAsync();
                 }
                 catch (Exception ex)
                 {

--- a/CoffeeTalk.Gui/Services/ConversationSessionService.cs
+++ b/CoffeeTalk.Gui/Services/ConversationSessionService.cs
@@ -105,7 +105,15 @@ public sealed class ConversationSessionService : IConversationSessionService, ID
         CancellationTokenSource cts)
     {
         if (previousTask is not null)
-            await previousTask.ConfigureAwait(false);
+        {
+            try
+            {
+                await previousTask.ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (previousTask.IsCanceled)
+            {
+            }
+        }
 
         cts.Token.ThrowIfCancellationRequested();
         _ui.ResetForNewConversation();


### PR DESCRIPTION
Addresses final cumulative review findings after PR #118: cancelled predecessor tasks no longer poison the next queued conversation, and mid-stream MoveNextAsync failures are surfaced without retrying a failed enumerator. Validation: 90 Release tests passed.