### PR TITLE
Close final cumulative review findings

### DIFF
--- a/CoffeeTalk.Core/Interfaces/IOperationalEventSink.cs
+++ b/CoffeeTalk.Core/Interfaces/IOperationalEventSink.cs
@@ -43,5 +43,6 @@ public interface IRetryService
     Task<T> ExecuteAsync<T>(
         Func<CancellationToken, Task<T>> operation,
         string operationName,
-        CancellationToken cancellationToken = default);
+        CancellationToken cancellationToken = default,
+        Func<CancellationToken, Task>? beforeRetry = null);
 }

--- a/CoffeeTalk.Core/Services/AgentConversationOrchestrator.cs
+++ b/CoffeeTalk.Core/Services/AgentConversationOrchestrator.cs
@@ -94,6 +94,7 @@ public class AgentConversationOrchestrator
     {
         int totalTurns = 0;
         int maxTotalTurns = _maxTurns * _personas.Count; // Total individual turns allowed
+        int failedAttempts = 0;
 
         while (totalTurns < maxTotalTurns)
         {
@@ -184,6 +185,7 @@ public class AgentConversationOrchestrator
             {
                 System.Diagnostics.Trace.WriteLine($"[Orchestrator] Operation timed out: {ex.Message}", "Warning");
                 await _ui.ShowErrorAsync("[red]❌ Operation timed out.[/]");
+                totalTurns++;
             }
             catch (Exception ex) when (
                 ex is StackOverflowException ||
@@ -197,6 +199,9 @@ public class AgentConversationOrchestrator
             {
                 System.Diagnostics.Trace.WriteLine($"[Orchestrator] Unexpected error: {ex.GetType().Name} - {ex.Message}", "Error");
                 await _ui.ShowErrorAsync("[red]❌ An unexpected error occurred.[/]");
+                failedAttempts++;
+                if (failedAttempts >= maxTotalTurns)
+                    break;
             }
 
             await _ui.ShowRuleAsync();

--- a/CoffeeTalk.Core/Services/AgentPersona.cs
+++ b/CoffeeTalk.Core/Services/AgentPersona.cs
@@ -86,7 +86,8 @@ public class AgentPersona
             var response = await _retryService.ExecuteAsync(
                 async cancellationToken => await _agent.RunAsync(contextMessage, cancellationToken: cancellationToken),
                 $"{Name} response",
-                cancellationToken);
+                cancellationToken,
+                _rateLimiter is null ? null : token => _rateLimiter.ThrottleAsync(0, token));
             responseText = response.ToString();
         }
         catch (OperationCanceledException)
@@ -159,7 +160,8 @@ public class AgentPersona
                     }
                 },
                 $"{Name} streaming response",
-                cancellationToken);
+                cancellationToken,
+                _rateLimiter is null ? null : token => _rateLimiter.ThrottleAsync(0, token));
             updates = initialUpdate.enumerator;
             var hasUpdate = initialUpdate.hasUpdate;
 
@@ -213,7 +215,8 @@ public class AgentPersona
         var response = await _retryService.ExecuteAsync(
             async token => await _agent.RunAsync(contextMessage, cancellationToken: token),
             $"{Name} response",
-            cancellationToken);
+            cancellationToken,
+            _rateLimiter is null ? null : token => _rateLimiter.ThrottleAsync(0, token));
         var responseText = response.ToString();
         _rateLimiter?.AccountAdditionalTokens(_rateLimiter.EstimateTokens(responseText));
         yield return responseText;

--- a/CoffeeTalk.Core/Services/RateLimiter.cs
+++ b/CoffeeTalk.Core/Services/RateLimiter.cs
@@ -72,6 +72,8 @@ public class RateLimiter
                 }
                 if (_cfg.TokensPerMinute.HasValue && _tokensInWindow + estimatedTokens > _cfg.TokensPerMinute.Value)
                 {
+                    if (estimatedTokens > _cfg.TokensPerMinute.Value)
+                        throw new InvalidOperationException($"Request token estimate exceeds per-minute cap ({_cfg.TokensPerMinute})");
                     var secondsLeft = 60 - (int)(DateTime.UtcNow - _windowStart).TotalSeconds;
                     delayMs = Math.Max(delayMs, Math.Max(100, secondsLeft * 1000));
                 }

--- a/CoffeeTalk.Core/Services/RetryService.cs
+++ b/CoffeeTalk.Core/Services/RetryService.cs
@@ -18,7 +18,8 @@ public sealed class RetryService : IRetryService
     public async Task<T> ExecuteAsync<T>(
         Func<CancellationToken, Task<T>> operation,
         string operationName,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        Func<CancellationToken, Task>? beforeRetry = null)
     {
         int retryCount = 0;
         int delaySeconds = _config.InitialDelaySeconds;
@@ -37,6 +38,8 @@ public sealed class RetryService : IRetryService
                     throw;
                 }
 
+                if (beforeRetry is not null)
+                    await beforeRetry(cancellationToken);
                 await Task.Delay(TimeSpan.FromSeconds(delaySeconds), cancellationToken);
                 delaySeconds = (int)(delaySeconds * _config.BackoffMultiplier);
             }
@@ -47,6 +50,8 @@ public sealed class RetryService : IRetryService
                     throw;
                 }
 
+                if (beforeRetry is not null)
+                    await beforeRetry(cancellationToken);
                 await Task.Delay(TimeSpan.FromSeconds(delaySeconds), cancellationToken);
                 delaySeconds = (int)(delaySeconds * _config.BackoffMultiplier);
             }

--- a/CoffeeTalk.Gui/Services/ConversationSessionService.cs
+++ b/CoffeeTalk.Gui/Services/ConversationSessionService.cs
@@ -85,7 +85,15 @@ public sealed class ConversationSessionService : IConversationSessionService, ID
             _ui.CancelIntervention();
 
             if (activeTask is not null)
-                await activeTask.ConfigureAwait(false);
+            {
+                try
+                {
+                    await activeTask.ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (activeTask.IsCanceled)
+                {
+                }
+            }
 
             lock (_gate)
             {


### PR DESCRIPTION
Bounds orchestrator failures, rejects oversized token requests instead of waiting forever, handles cancellation during queued loads, and rate-limits retry attempts for persona calls. Validation: 90 Release tests and Release build passed.