### PR TITLE
Improve agent conversations and observability

### DIFF
--- a/CoffeeTalk.Core/Interfaces/IOperationalEventSink.cs
+++ b/CoffeeTalk.Core/Interfaces/IOperationalEventSink.cs
@@ -5,7 +5,14 @@ public enum OperationalEventKind
     RetryAttempt,
     RetryTerminalFailure,
     OrchestratorDecision,
-    OperationFailure
+    OperationFailure,
+    RequestStarted,
+    RequestThinking,
+    RequestCompleted,
+    RequestFailed,
+    ToolStarted,
+    ToolCompleted,
+    ToolFailed
 }
 
 public sealed record OperationalEvent(
@@ -18,6 +25,18 @@ public sealed record OperationalEvent(
     string? Reason = null)
 {
     public Exception? Exception { get; init; }
+    public string? RequestId { get; init; }
+    public int? PromptCharacters { get; init; }
+    public int? EstimatedPromptTokens { get; init; }
+    public int? OutputCharacters { get; init; }
+    public int? EstimatedOutputTokens { get; init; }
+    public long? InputTokens { get; init; }
+    public long? OutputTokens { get; init; }
+    public long? TotalTokens { get; init; }
+    public long? DurationMilliseconds { get; init; }
+    public long? FirstTokenMilliseconds { get; init; }
+    public int? ArgumentCharacters { get; init; }
+    public int? ResultCharacters { get; init; }
 }
 
 public interface IOperationalEventSink

--- a/CoffeeTalk.Core/Services/AgentBuilder.cs
+++ b/CoffeeTalk.Core/Services/AgentBuilder.cs
@@ -22,8 +22,7 @@ public static class AgentBuilder
 
         OpenAI.Chat.ChatClient chatClient = config.Type.ToLower() switch
         {
-            "openai" => new OpenAI.OpenAIClient(new System.ClientModel.ApiKeyCredential(config.ApiKey))
-                .GetChatClient(config.ModelId),
+            "openai" => CreateOpenAIClient(config),
             
             "ollama" => new OpenAI.OpenAIClient(
                 new System.ClientModel.ApiKeyCredential("not-needed"), // Ollama doesn't require API key
@@ -63,5 +62,19 @@ public static class AgentBuilder
             new System.ClientModel.ApiKeyCredential(config.ApiKey));
 
         return azureClient.GetChatClient(deployment);
+    }
+
+    private static OpenAI.Chat.ChatClient CreateOpenAIClient(LlmProviderConfig config)
+    {
+        var apiKey = string.IsNullOrWhiteSpace(config.ApiKey) ? "not-needed" : config.ApiKey;
+        var credential = new System.ClientModel.ApiKeyCredential(apiKey);
+
+        if (string.IsNullOrWhiteSpace(config.Endpoint))
+            return new OpenAI.OpenAIClient(credential).GetChatClient(config.ModelId);
+
+        return new OpenAI.OpenAIClient(
+            credential,
+            new OpenAI.OpenAIClientOptions { Endpoint = new Uri(config.Endpoint) })
+            .GetChatClient(config.ModelId);
     }
 }

--- a/CoffeeTalk.Core/Services/AgentConversationOrchestrator.cs
+++ b/CoffeeTalk.Core/Services/AgentConversationOrchestrator.cs
@@ -156,8 +156,20 @@ public class AgentConversationOrchestrator
 
                 if (selectedPersona == null)
                 {
-                    await _ui.ShowMessageAsync("\n[yellow]⚠️  Orchestrator couldn't select a speaker. Ending conversation.[/]");
-                    break;
+                    var consensus = await VerifyConsensusAsync(currentMessage, conversationHistory, cancellationToken);
+                    if (consensus.Reached)
+                    {
+                        await _ui.ShowRuleAsync("Consensus reached");
+                        await _ui.ShowMessageAsync(
+                            "\n[bold green]✅ All personas agree that the conversation can conclude.[/]");
+                        break;
+                    }
+
+                    currentMessage = consensus.FollowUpMessage;
+                    await _ui.ShowMessageAsync(
+                        $"\n[yellow]⚠️  Consensus has not been reached. The orchestrator will request another contribution.[/]\n" +
+                        $"{Escape(consensus.FollowUpMessage)}");
+                    continue;
                 }
 
                 await _ui.ShowAgentResponseAsync(selectedPersona.Name, response);
@@ -250,6 +262,62 @@ public class AgentConversationOrchestrator
 
         await TryExtractMemoryAsync(topic, conversationHistory, cancellationToken);
         await TryAutoSaveAsync(cancellationToken);
+    }
+
+    private async Task<(bool Reached, string FollowUpMessage)> VerifyConsensusAsync(
+        string currentMessage,
+        List<string> conversationHistory,
+        CancellationToken cancellationToken)
+    {
+        await _ui.SetStatusAsync("Personas are checking consensus...");
+        var assessments = await Task.WhenAll(
+            _personas.Select(async persona =>
+            {
+                try
+                {
+                    var response = await persona.AssessConsensusAsync(
+                        currentMessage, conversationHistory, cancellationToken);
+                    var lines = response
+                        .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                    var vote = lines.FirstOrDefault(line =>
+                        line.StartsWith("CONSENSUS:", StringComparison.OrdinalIgnoreCase));
+                    var agrees = vote is not null &&
+                        vote.Contains("YES", StringComparison.OrdinalIgnoreCase);
+                    var reason = lines.FirstOrDefault(line =>
+                        line.StartsWith("Reason:", StringComparison.OrdinalIgnoreCase))
+                        ?? "No rationale provided.";
+                    return (persona.Name, Agrees: agrees, Reason: reason);
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    return (persona.Name, Agrees: false, Reason: $"Consensus check failed: {ex.Message}");
+                }
+            }));
+
+        foreach (var assessment in assessments)
+        {
+            await _ui.ShowMessageAsync(
+                $"[dim]Consensus — {Escape(assessment.Name)}: " +
+                $"{(assessment.Agrees ? "AGREE" : "REVISE")} — {Escape(assessment.Reason)}[/]");
+        }
+
+        var dissent = assessments.Where(assessment => !assessment.Agrees).ToList();
+        if (dissent.Count == 0)
+        {
+            return (true, string.Empty);
+        }
+
+        var concerns = string.Join(
+            "\n",
+            dissent.Select(assessment => $"- {assessment.Name}: {assessment.Reason}"));
+        return (
+            false,
+            $"The consensus check found these unresolved concerns:\n{concerns}\n" +
+            "Address the concerns in the document before proposing completion again.");
     }
 
     private async Task RunRoundRobinConversationAsync(List<string> conversationHistory, string currentMessage, CancellationToken cancellationToken)
@@ -431,6 +499,7 @@ public class AgentConversationOrchestrator
         CancellationToken cancellationToken)
     {
         var response = new StringBuilder();
+        var lastDocumentPreview = persona.GetDocumentPreview();
         try
         {
             await foreach (var chunk in persona.RespondStreamingAsync(
@@ -441,6 +510,13 @@ public class AgentConversationOrchestrator
                 cancellationToken.ThrowIfCancellationRequested();
                 response.Append(chunk);
                 await _ui.ShowAgentResponseChunkAsync(persona.Name, chunk);
+
+                var documentPreview = persona.GetDocumentPreview();
+                if (!string.Equals(documentPreview, lastDocumentPreview, StringComparison.Ordinal))
+                {
+                    lastDocumentPreview = documentPreview;
+                    await _ui.ShowDocumentPreviewAsync(documentPreview);
+                }
             }
         }
         catch

--- a/CoffeeTalk.Core/Services/AgentOrchestrator.cs
+++ b/CoffeeTalk.Core/Services/AgentOrchestrator.cs
@@ -19,6 +19,8 @@ public partial class AgentOrchestrator
     private readonly IRetryService _retryService;
     private readonly IOperationalEventSink _eventSink;
     private readonly RateLimiter? _rateLimiter;
+    private AgentThread? _thread;
+    private bool _threadInitialized;
 
     public AgentOrchestrator(AIAgent agent, OrchestratorConfig config, CollaborativeMarkdownDocument doc, List<AgentPersona> personas, IRetryService retryService, IOperationalEventSink? eventSink = null, RateLimiter? rateLimiter = null)
     {
@@ -129,7 +131,8 @@ Reason: Document complete, all personas contributed, clear consensus reached");
         if (_rateLimiter != null)
             await _rateLimiter.ThrottleAsync(_rateLimiter.EstimateTokens(prompt), cancellationToken);
         var response = await _retryService.ExecuteAsync(
-            async cancellationToken => await _agent.RunAsync(prompt, cancellationToken: cancellationToken),
+            async cancellationToken => await _agent.RunAsync(
+                prompt, GetThread(), cancellationToken: cancellationToken),
             "Orchestrator summarization",
             cancellationToken);
         var result = response.ToString();
@@ -145,15 +148,28 @@ Reason: Document complete, all personas contributed, clear consensus reached");
     {
         // Build context for orchestrator
         var context = BuildOrchestratorContext(currentMessage, conversationHistory, turnsRemaining);
+        var telemetry = new RequestTelemetry(_eventSink, "Orchestrator selection", context);
         if (_rateLimiter != null)
             await _rateLimiter.ThrottleAsync(_rateLimiter.EstimateTokens(context), cancellationToken);
 
         // Execute with retry logic for rate limiting (HTTP 429)
-        var response = await _retryService.ExecuteAsync(
-            async cancellationToken => await _agent.RunAsync(context, cancellationToken: cancellationToken),
-            "Orchestrator selection",
-            cancellationToken);
+        AgentRunResponse response;
+        try
+        {
+            response = await _retryService.ExecuteAsync(
+                async cancellationToken => await _agent.RunAsync(
+                    context, GetThread(), cancellationToken: cancellationToken),
+                "Orchestrator selection",
+                cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            telemetry.Fail(ex);
+            throw;
+        }
         var responseText = response.ToString();
+        telemetry.AppendOutput(responseText);
+        telemetry.Complete(response.Usage);
         _rateLimiter?.AccountAdditionalTokens(_rateLimiter.EstimateTokens(responseText));
 
         // Check if orchestrator signals conclusion
@@ -190,6 +206,23 @@ Reason: Document complete, all personas contributed, clear consensus reached");
     private static string LimitReason(string reason) =>
         reason.Length > 200 ? reason[..200] : reason;
 
+    private AgentThread? GetThread()
+    {
+        if (_threadInitialized)
+            return _thread;
+
+        _threadInitialized = true;
+        try
+        {
+            _thread = _agent.GetNewThread();
+        }
+        catch (NotSupportedException)
+        {
+        }
+
+        return _thread;
+    }
+
     private string BuildOrchestratorContext(string currentMessage, List<string> history, int turnsRemaining)
     {
         var sb = new StringBuilder();
@@ -205,10 +238,12 @@ Reason: Document complete, all personas contributed, clear consensus reached");
             sb.AppendLine();
         }
 
-        // Add document state
-        var headings = _doc.ListHeadings();
+        // Include the full document so speaker selection reflects actual content and gaps.
+        var document = _doc.Snapshot();
         sb.AppendLine("Current document state:");
-        sb.AppendLine(string.IsNullOrWhiteSpace(headings) ? "[Document is empty]" : headings);
+        sb.AppendLine("```markdown");
+        sb.AppendLine(string.IsNullOrWhiteSpace(document) ? "[Document is empty]" : document);
+        sb.AppendLine("```");
         sb.AppendLine();
 
         // Add participation stats

--- a/CoffeeTalk.Core/Services/AgentPersona.cs
+++ b/CoffeeTalk.Core/Services/AgentPersona.cs
@@ -1,4 +1,5 @@
 using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
 using CoffeeTalk.Core.Interfaces;
 using CoffeeTalk.Models;
 using System.Runtime.CompilerServices;
@@ -18,6 +19,9 @@ public class AgentPersona
     private readonly int _agentCount;
     private readonly IRetryService _retryService;
     private readonly LlmProviderConfig _providerConfig;
+    private readonly IOperationalEventSink _eventSink;
+    private AgentThread? _thread;
+    private bool _threadInitialized;
 
     public string Name => _config.Name;
     public string SystemPrompt => _config.SystemPrompt;
@@ -32,7 +36,8 @@ public class AgentPersona
         int agentCount,
         IRetryService retryService,
         IReadOnlyCollection<string>? effectiveToolNames = null,
-        LlmProviderConfig? providerConfig = null)
+        LlmProviderConfig? providerConfig = null,
+        IOperationalEventSink? eventSink = null)
     {
         _agent = agent;
         _config = config;
@@ -42,6 +47,7 @@ public class AgentPersona
         _agentCount = agentCount;
         _retryService = retryService;
         _providerConfig = providerConfig ?? new LlmProviderConfig();
+        _eventSink = eventSink ?? NullOperationalEventSink.Instance;
         EffectiveToolNames = effectiveToolNames?.ToList() ?? [];
     }
 
@@ -71,6 +77,7 @@ public class AgentPersona
     public async Task<string> RespondAsync(string currentMessage, List<string> conversationHistory, CancellationToken cancellationToken = default)
     {
         var contextMessage = BuildContext(currentMessage, conversationHistory);
+        var telemetry = new RequestTelemetry(_eventSink, $"{Name} response", contextMessage);
 
         // Throttle based on an estimated token count
         var estimatedTokens = _rateLimiter?.EstimateTokens(contextMessage) ?? 0;
@@ -84,11 +91,14 @@ public class AgentPersona
         try
         {
             var response = await _retryService.ExecuteAsync(
-                async cancellationToken => await _agent.RunAsync(contextMessage, cancellationToken: cancellationToken),
+                async cancellationToken => await _agent.RunAsync(
+                    contextMessage, GetThread(), cancellationToken: cancellationToken),
                 $"{Name} response",
                 cancellationToken,
                 _rateLimiter is null ? null : token => _rateLimiter.ThrottleAsync(0, token));
             responseText = response.ToString();
+            telemetry.AppendOutput(responseText);
+            telemetry.Complete(response.Usage);
         }
         catch (OperationCanceledException)
         {
@@ -96,14 +106,17 @@ public class AgentPersona
         }
         catch (TimeoutException)
         {
+            telemetry.Fail(new TimeoutException("Operation timed out."));
             responseText = $"Error: Operation timed out.";
         }
         catch (HttpRequestException)
         {
+            telemetry.Fail(new HttpRequestException("Network error occurred."));
             responseText = $"Error: Network error occurred.";
         }
         catch (Exception ex) when (ex is not OutOfMemoryException && ex is not StackOverflowException)
         {
+            telemetry.Fail(ex);
             responseText = $"Error: An unexpected error occurred.";
         }
 
@@ -111,6 +124,45 @@ public class AgentPersona
         _rateLimiter?.AccountAdditionalTokens(_rateLimiter.EstimateTokens(responseText));
 
         return responseText;
+    }
+
+    public async Task<string> AssessConsensusAsync(
+        string currentMessage,
+        List<string> conversationHistory,
+        CancellationToken cancellationToken = default)
+    {
+        var contextMessage = BuildContext(
+            $"""
+            Assess whether the current document has reached consensus.
+            Review the full Markdown document and recent discussion.
+            The orchestrator's proposed completion message is:
+            {currentMessage}
+            Return exactly:
+            CONSENSUS: YES or CONSENSUS: NO
+            Reason: one concise sentence explaining your assessment.
+            Use CONSENSUS: NO if your expertise identifies a material unresolved issue.
+            """,
+            conversationHistory);
+        var telemetry = new RequestTelemetry(_eventSink, $"{Name} consensus check", contextMessage);
+
+        try
+        {
+            var response = await _retryService.ExecuteAsync(
+                async token => await _agent.RunAsync(
+                    contextMessage, GetThread(), cancellationToken: token),
+                $"{Name} consensus check",
+                cancellationToken,
+                _rateLimiter is null ? null : token => _rateLimiter.ThrottleAsync(0, token));
+            var responseText = response.ToString();
+            telemetry.AppendOutput(responseText);
+            telemetry.Complete(response.Usage);
+            return responseText;
+        }
+        catch (Exception ex)
+        {
+            telemetry.Fail(ex);
+            throw;
+        }
     }
 
     public async IAsyncEnumerable<string> RespondStreamingAsync(
@@ -140,14 +192,16 @@ public class AgentPersona
 
         var emitted = false;
         Exception? failure = null;
+        var telemetry = new RequestTelemetry(_eventSink, $"{Name} streaming response", contextMessage);
         IAsyncEnumerator<AgentRunResponseUpdate>? updates = null;
+        (IAsyncEnumerator<AgentRunResponseUpdate> enumerator, bool hasUpdate) initialUpdate;
         try
         {
-            var initialUpdate = await _retryService.ExecuteAsync(
+            initialUpdate = await _retryService.ExecuteAsync(
                 async token =>
                 {
                     var enumerator = _agent
-                        .RunStreamingAsync(contextMessage, cancellationToken: token)
+                        .RunStreamingAsync(contextMessage, GetThread(), cancellationToken: token)
                         .GetAsyncEnumerator(token);
                     try
                     {
@@ -162,16 +216,26 @@ public class AgentPersona
                 $"{Name} streaming response",
                 cancellationToken,
                 _rateLimiter is null ? null : token => _rateLimiter.ThrottleAsync(0, token));
-            updates = initialUpdate.enumerator;
-            var hasUpdate = initialUpdate.hasUpdate;
-
+        }
+        catch (Exception ex)
+        {
+            telemetry.Fail(ex);
+            throw;
+        }
+        updates = initialUpdate.enumerator;
+        var hasUpdate = initialUpdate.hasUpdate;
+        try
+        {
             while (hasUpdate)
             {
                 cancellationToken.ThrowIfCancellationRequested();
+                foreach (var reasoning in updates.Current.Contents.OfType<TextReasoningContent>())
+                    telemetry.PublishThinking(reasoning.Text);
                 var text = updates.Current.Text;
                 if (!string.IsNullOrEmpty(text))
                 {
                     emitted = true;
+                    telemetry.AppendOutput(text);
                     _rateLimiter?.AccountAdditionalTokens(_rateLimiter.EstimateTokens(text));
                     yield return text;
                 }
@@ -189,22 +253,33 @@ public class AgentPersona
         }
         finally
         {
-            if (updates is not null)
-                await updates.DisposeAsync();
+            await updates.DisposeAsync();
         }
 
         if (failure is OperationCanceledException)
+        {
+            telemetry.Fail(failure);
             throw failure;
+        }
         if (failure is not null && emitted)
+        {
+            telemetry.Fail(failure);
             throw failure;
+        }
         if (failure is not null && UseBufferedFallback())
         {
+            telemetry.Fail(failure);
             await foreach (var chunk in FallbackToBufferedAsync(contextMessage, cancellationToken))
                 yield return chunk;
         }
         else if (failure is not null)
         {
+            telemetry.Fail(failure);
             throw failure;
+        }
+        else
+        {
+            telemetry.Complete();
         }
     }
 
@@ -213,7 +288,7 @@ public class AgentPersona
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         var response = await _retryService.ExecuteAsync(
-            async token => await _agent.RunAsync(contextMessage, cancellationToken: token),
+            async token => await _agent.RunAsync(contextMessage, GetThread(), cancellationToken: token),
             $"{Name} response",
             cancellationToken,
             _rateLimiter is null ? null : token => _rateLimiter.ThrottleAsync(0, token));
@@ -230,7 +305,7 @@ public class AgentPersona
             : currentMessage;
         var docState = GetDocumentState();
         if (!string.IsNullOrWhiteSpace(docState))
-            contextMessage = $"Current document state:\n{docState}\n\n{contextMessage}";
+            contextMessage = $"Current document state (use this exact Markdown as the source of truth):\n```markdown\n{docState}\n```\n\n{contextMessage}";
 
         var currentTurn = (conversationHistory.Count / _agentCount) + 1;
         var turnsRemaining = _maxTurns - currentTurn;
@@ -238,6 +313,24 @@ public class AgentPersona
             contextMessage = $"⚠️ IMPORTANT: Only {turnsRemaining} turn(s) remaining. Focus on wrapping up and reaching a clear conclusion.\n\n{contextMessage}";
 
         return $"{GetPersonaCollaborationGuidelines()}\n\n{contextMessage}";
+    }
+
+    private AgentThread? GetThread()
+    {
+        if (_threadInitialized)
+            return _thread;
+
+        _threadInitialized = true;
+        try
+        {
+            _thread = _agent.GetNewThread();
+        }
+        catch (NotSupportedException)
+        {
+            // Some test doubles and custom agents only support stateless runs.
+        }
+
+        return _thread;
     }
 
     private bool SupportsStreaming()
@@ -293,8 +386,8 @@ Completion Strategy:
     {
         try
         {
-            var headings = _doc.ListHeadings();
-            return string.IsNullOrWhiteSpace(headings) ? "Document is empty" : headings;
+            var content = _doc.Snapshot();
+            return string.IsNullOrWhiteSpace(content) ? "Document is empty" : content;
         }
         catch (Exception ex) when (ex is not OutOfMemoryException && ex is not StackOverflowException)
         {
@@ -306,9 +399,8 @@ Completion Strategy:
     {
         try
         {
-            var headings = _doc.ListHeadings();
-            if (string.IsNullOrWhiteSpace(headings)) return "  [Document is empty]";
-            return string.Join("\n", headings.Split('\n').Select(h => $"  {h}"));
+            var content = _doc.Snapshot();
+            return string.IsNullOrWhiteSpace(content) ? "  [Document is empty]" : content;
         }
         catch (Exception ex) when (ex is not OutOfMemoryException && ex is not StackOverflowException)
         {

--- a/CoffeeTalk.Core/Services/AgentPersonaGenerator.cs
+++ b/CoffeeTalk.Core/Services/AgentPersonaGenerator.cs
@@ -13,12 +13,18 @@ public class AgentPersonaGenerator
     private readonly AIAgent _agent;
     private readonly IRetryService _retryService;
     private readonly RateLimiter? _rateLimiter;
+    private readonly IOperationalEventSink _eventSink;
 
-    public AgentPersonaGenerator(AIAgent agent, IRetryService retryService, RateLimiter? rateLimiter = null)
+    public AgentPersonaGenerator(
+        AIAgent agent,
+        IRetryService retryService,
+        RateLimiter? rateLimiter = null,
+        IOperationalEventSink? eventSink = null)
     {
         _agent = agent;
         _retryService = retryService;
         _rateLimiter = rateLimiter;
+        _eventSink = eventSink ?? NullOperationalEventSink.Instance;
     }
 
     public AgentPersonaGenerator(AIAgent agent)
@@ -46,14 +52,26 @@ REQUIREMENTS:
         int count = Math.Clamp(requestedCount, 2, 10);
 
         var prompt = $"Topic: {topic}\nGenerate {count} personas for this conversation. JSON array only, in this shape:\n[\n  {{\"name\":\"<ShortUniqueName>\",\"systemPrompt\":\"You are <ShortUniqueName>, <1-2 sentence role and perspective>. Collaborate concisely, avoid redundancy, and use tools effectively when available.\"}},\n  ...\n]";
+        var telemetry = new RequestTelemetry(_eventSink, "Generate personas", prompt);
 
         if (_rateLimiter != null)
             await _rateLimiter.ThrottleAsync(_rateLimiter.EstimateTokens(prompt), cancellationToken);
-        var response = await _retryService.ExecuteAsync(
-            async cancellationToken => await _agent.RunAsync(prompt, cancellationToken: cancellationToken),
-            "Generate personas",
-            cancellationToken);
+        AgentRunResponse response;
+        try
+        {
+            response = await _retryService.ExecuteAsync(
+                async cancellationToken => await _agent.RunAsync(prompt, cancellationToken: cancellationToken),
+                "Generate personas",
+                cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            telemetry.Fail(ex);
+            throw;
+        }
         var responseText = response.ToString();
+        telemetry.AppendOutput(responseText);
+        telemetry.Complete(response.Usage);
         _rateLimiter?.AccountAdditionalTokens(_rateLimiter.EstimateTokens(responseText));
 
         // Try to parse JSON array

--- a/CoffeeTalk.Core/Services/ConversationPipelineBuilder.cs
+++ b/CoffeeTalk.Core/Services/ConversationPipelineBuilder.cs
@@ -97,7 +97,7 @@ public sealed class ConversationPipelineBuilder
 
         var sharedDocument = new CollaborativeMarkdownDocument(_dataPaths);
         var toolsConfig = settings.Tools ?? new ToolsConfig();
-        var markdownTools = new MarkdownToolFunctions(sharedDocument, toolsConfig);
+        var markdownTools = new MarkdownToolFunctions(sharedDocument, toolsConfig, _eventSink);
         var tools = markdownTools.CreateTools();
         if (toolsConfig.RequireToolsVerification && !markdownTools.VerifyTools(tools))
         {
@@ -217,7 +217,7 @@ public sealed class ConversationPipelineBuilder
             settings.LlmProvider,
             "PersonaGenerator",
             AgentPersonaGenerator.BuildSystemPrompt());
-        var generator = new AgentPersonaGenerator(generatorAgent, retryService, rateLimiter);
+        var generator = new AgentPersonaGenerator(generatorAgent, retryService, rateLimiter, _eventSink);
         var requested = Math.Clamp(dynamicConfig.Count, 2, 10);
         var replace = dynamicConfig.Mode?.Equals("replace", StringComparison.OrdinalIgnoreCase) == true;
         var reserved = replace ? Array.Empty<string>() : configured.Select(persona => persona.Name);
@@ -310,7 +310,8 @@ public sealed class ConversationPipelineBuilder
             totalPersonaCount ?? agentCount,
             retryService,
             personaTools.Select(tool => tool.Name).ToList(),
-            settings.LlmProvider);
+            settings.LlmProvider,
+            _eventSink);
     }
 
     private static void ValidateAllowedTools(IEnumerable<PersonaConfig> configs, AIFunction[] tools)

--- a/CoffeeTalk.Core/Services/MarkdownToolFunctions.cs
+++ b/CoffeeTalk.Core/Services/MarkdownToolFunctions.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.AI;
+using CoffeeTalk.Core.Interfaces;
 using System.ComponentModel;
 using System.Text.Json;
 using CoffeeTalk.Models;
@@ -11,12 +12,17 @@ namespace CoffeeTalk.Services;
 public class MarkdownToolFunctions
 {
     private readonly CollaborativeMarkdownDocument _doc;
+    private readonly IOperationalEventSink _eventSink;
     public ToolsConfig Configuration { get; }
 
-    public MarkdownToolFunctions(CollaborativeMarkdownDocument doc, ToolsConfig? configuration = null)
+    public MarkdownToolFunctions(
+        CollaborativeMarkdownDocument doc,
+        ToolsConfig? configuration = null,
+        IOperationalEventSink? eventSink = null)
     {
         _doc = doc;
         Configuration = configuration ?? new ToolsConfig();
+        _eventSink = eventSink ?? NullOperationalEventSink.Instance;
     }
 
     /// <summary>
@@ -50,56 +56,37 @@ public class MarkdownToolFunctions
 
     [Description("Set the title (H1) of the shared markdown document")]
     public string SetTitle([Description("The title text to set as H1")] string title)
-    {
-        _doc.SetTitle(title);
-        return _doc.GetContent();
-    }
+        => ExecuteTool("SetTitle", title, () => _doc.SetTitle(title));
 
     [Description("Add a heading to the shared markdown document")]
     public string AddHeading(
         [Description("Heading text")] string text,
         [Description("Heading level 1-6; default 2")] int level = 2)
-    {
-        _doc.AddHeading(text, level);
-        return _doc.GetContent();
-    }
+        => ExecuteTool("AddHeading", $"{text}\nlevel={level}", () => _doc.AddHeading(text, level));
 
     [Description("Append a paragraph to the shared markdown document")]
     public string AppendParagraph([Description("Paragraph text")] string text)
-    {
-        _doc.AppendParagraph(text);
-        return _doc.GetContent();
-    }
+        => ExecuteTool("AppendParagraph", text, () => _doc.AppendParagraph(text));
 
     [Description("Insert content after a specific heading; creates the heading if missing")]
     public string InsertAfterHeading(
         [Description("Heading text to insert after")] string headingText,
         [Description("Markdown content to insert")] string content)
-    {
-        _doc.InsertAfterHeading(headingText, content);
-        return _doc.GetContent();
-    }
+        => ExecuteTool("InsertAfterHeading", $"{headingText}\n{content}", () => _doc.InsertAfterHeading(headingText, content));
 
     [Description("Replace the content of a section under a heading with new, concise content. Creates the section if not present.")]
     public string ReplaceSection(
         [Description("The exact heading text whose section content should be replaced")] string headingText,
         [Description("The new concise markdown content for the section")] string content)
-    {
-        _doc.ReplaceSection(headingText, content);
-        return _doc.GetContent();
-    }
+        => ExecuteTool("ReplaceSection", $"{headingText}\n{content}", () => _doc.ReplaceSection(headingText, content));
 
     [Description("List all headings currently in the document")]
     public string ListHeadings()
-    {
-        return _doc.ListHeadings();
-    }
+        => ExecuteTool("ListHeadings", null, () => _doc.ListHeadings());
 
     [Description("Save the shared markdown document to disk and return the full file path")]
     public Task<string> SaveToFileAsync([Description("Output path relative to the CoffeeTalk exports directory; defaults to conversation.md")] string? path = null)
-    {
-        return _doc.SaveToFileAsync(path ?? "conversation.md");
-    }
+        => ExecuteToolAsync("SaveToFile", path, () => _doc.SaveToFileAsync(path ?? "conversation.md"));
 
     [Description("Fallback tool dispatcher for providers that return tool calls as JSON")]
     public string ExecuteJsonTool(
@@ -123,5 +110,41 @@ public class MarkdownToolFunctions
             "ListHeadings" => ListHeadings(),
             _ => throw new ArgumentException($"Unsupported markdown tool: {toolName}", nameof(toolName))
         };
+    }
+
+    private string ExecuteTool(string name, string? arguments, Action action)
+    {
+        var telemetry = new ToolTelemetry(_eventSink, $"Tool: {name}", arguments);
+        try
+        {
+            action();
+            var result = _doc.GetContent();
+            telemetry.Complete(result);
+            return result;
+        }
+        catch (Exception ex)
+        {
+            telemetry.Fail(ex);
+            throw;
+        }
+    }
+
+    private async Task<string> ExecuteToolAsync(
+        string name,
+        string? arguments,
+        Func<Task<string>> action)
+    {
+        var telemetry = new ToolTelemetry(_eventSink, $"Tool: {name}", arguments);
+        try
+        {
+            var result = await action();
+            telemetry.Complete(result);
+            return result;
+        }
+        catch (Exception ex)
+        {
+            telemetry.Fail(ex);
+            throw;
+        }
     }
 }

--- a/CoffeeTalk.Core/Services/RequestTelemetry.cs
+++ b/CoffeeTalk.Core/Services/RequestTelemetry.cs
@@ -1,0 +1,104 @@
+using CoffeeTalk.Core.Interfaces;
+using Microsoft.Extensions.AI;
+using System.Diagnostics;
+
+namespace CoffeeTalk.Services;
+
+internal sealed class RequestTelemetry
+{
+    private readonly IOperationalEventSink _eventSink;
+    private readonly Stopwatch _stopwatch = Stopwatch.StartNew();
+    private readonly string _requestId = Guid.NewGuid().ToString("N")[..8];
+    private readonly string _operation;
+    private readonly int _promptCharacters;
+    private int _outputCharacters;
+    private long? _firstTokenMilliseconds;
+    private UsageDetails? _usage;
+
+    public RequestTelemetry(
+        IOperationalEventSink eventSink,
+        string operation,
+        string prompt)
+    {
+        _eventSink = eventSink;
+        _operation = operation;
+        _promptCharacters = prompt.Length;
+        _eventSink.Publish(new OperationalEvent(
+            OperationalEventKind.RequestStarted,
+            operation,
+            Reason: $"request={_requestId}")
+        {
+            RequestId = _requestId,
+            PromptCharacters = _promptCharacters,
+            EstimatedPromptTokens = EstimateTokens(_promptCharacters)
+        });
+    }
+
+    public void AppendOutput(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+            return;
+
+        _outputCharacters += text.Length;
+        _firstTokenMilliseconds ??= _stopwatch.ElapsedMilliseconds;
+    }
+
+    public void PublishThinking(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            return;
+
+        _eventSink.Publish(new OperationalEvent(
+            OperationalEventKind.RequestThinking,
+            _operation,
+            Reason: $"request={_requestId}; {text.Trim()} ")
+        {
+            RequestId = _requestId
+        });
+    }
+
+    public void Complete(UsageDetails? usage = null)
+    {
+        _usage = usage;
+        _eventSink.Publish(new OperationalEvent(
+            OperationalEventKind.RequestCompleted,
+            _operation,
+            Reason: $"request={_requestId}")
+        {
+            RequestId = _requestId,
+            PromptCharacters = _promptCharacters,
+            EstimatedPromptTokens = EstimateTokens(_promptCharacters),
+            OutputCharacters = _outputCharacters,
+            EstimatedOutputTokens = EstimateTokens(_outputCharacters),
+            InputTokens = _usage?.InputTokenCount,
+            OutputTokens = _usage?.OutputTokenCount,
+            TotalTokens = _usage?.TotalTokenCount,
+            DurationMilliseconds = _stopwatch.ElapsedMilliseconds,
+            FirstTokenMilliseconds = _firstTokenMilliseconds
+        });
+    }
+
+    public void Fail(Exception exception)
+    {
+        _eventSink.Publish(new OperationalEvent(
+            OperationalEventKind.RequestFailed,
+            _operation,
+            Reason: $"request={_requestId}; {exception.Message}")
+        {
+            RequestId = _requestId,
+            PromptCharacters = _promptCharacters,
+            EstimatedPromptTokens = EstimateTokens(_promptCharacters),
+            OutputCharacters = _outputCharacters,
+            EstimatedOutputTokens = EstimateTokens(_outputCharacters),
+            InputTokens = _usage?.InputTokenCount,
+            OutputTokens = _usage?.OutputTokenCount,
+            TotalTokens = _usage?.TotalTokenCount,
+            DurationMilliseconds = _stopwatch.ElapsedMilliseconds,
+            FirstTokenMilliseconds = _firstTokenMilliseconds,
+            Exception = exception
+        });
+    }
+
+    private static int EstimateTokens(int characters) =>
+        characters == 0 ? 0 : (characters + 3) / 4;
+}

--- a/CoffeeTalk.Core/Services/ToolTelemetry.cs
+++ b/CoffeeTalk.Core/Services/ToolTelemetry.cs
@@ -1,0 +1,50 @@
+using CoffeeTalk.Core.Interfaces;
+using System.Diagnostics;
+
+namespace CoffeeTalk.Services;
+
+internal sealed class ToolTelemetry
+{
+    private readonly IOperationalEventSink _eventSink;
+    private readonly string _operation;
+    private readonly string _requestId = Guid.NewGuid().ToString("N")[..8];
+    private readonly Stopwatch _stopwatch = Stopwatch.StartNew();
+    private readonly int _argumentCharacters;
+
+    public ToolTelemetry(IOperationalEventSink eventSink, string operation, string? arguments)
+    {
+        _eventSink = eventSink;
+        _operation = operation;
+        _argumentCharacters = arguments?.Length ?? 0;
+        _eventSink.Publish(new OperationalEvent(OperationalEventKind.ToolStarted, operation, Reason: $"tool={_requestId}")
+        {
+            RequestId = _requestId,
+            ArgumentCharacters = _argumentCharacters
+        });
+    }
+
+    public void Complete(string? result)
+    {
+        _eventSink.Publish(new OperationalEvent(OperationalEventKind.ToolCompleted, _operation, Reason: $"tool={_requestId}")
+        {
+            RequestId = _requestId,
+            ArgumentCharacters = _argumentCharacters,
+            ResultCharacters = result?.Length ?? 0,
+            DurationMilliseconds = _stopwatch.ElapsedMilliseconds
+        });
+    }
+
+    public void Fail(Exception exception)
+    {
+        _eventSink.Publish(new OperationalEvent(
+            OperationalEventKind.ToolFailed,
+            _operation,
+            Reason: $"tool={_requestId}; {exception.Message}")
+        {
+            RequestId = _requestId,
+            ArgumentCharacters = _argumentCharacters,
+            DurationMilliseconds = _stopwatch.ElapsedMilliseconds,
+            Exception = exception
+        });
+    }
+}

--- a/CoffeeTalk.Core/Services/WorkspaceService.cs
+++ b/CoffeeTalk.Core/Services/WorkspaceService.cs
@@ -106,21 +106,23 @@ public sealed class WorkspaceService : IWorkspaceService
         {
             try
             {
-                metadata = ReadMetadataAsync(
-                    ResolveWorkspacePath(activeId), activeId, CancellationToken.None).GetAwaiter().GetResult();
+                metadata = ReadMetadata(
+                    ResolveWorkspacePath(activeId), activeId);
             }
             catch (UnauthorizedAccessException) { }
         }
         if (metadata is null)
         {
-            metadata = ReadMetadataAsync(ResolveWorkspacePath("default"), "default", CancellationToken.None).GetAwaiter().GetResult();
+            metadata = ReadMetadata(ResolveWorkspacePath("default"), "default");
             if (metadata is null)
             {
                 var path = ResolveWorkspacePath("default");
                 Directory.CreateDirectory(path);
                 MigrateLegacyFiles(path);
                 metadata = new WorkspaceMetadata { Id = "default", Name = "Default" };
-                WriteMetadataAsync(path, metadata, CancellationToken.None).GetAwaiter().GetResult();
+                File.WriteAllText(
+                    Path.Combine(path, MetadataFile),
+                    JsonSerializer.Serialize(metadata, _json));
             }
             File.WriteAllText(Path.Combine(_paths.BaseRootDirectory, ActiveFile),
                 JsonSerializer.Serialize(new { id = metadata.Id }, _json));
@@ -141,6 +143,26 @@ public sealed class WorkspaceService : IWorkspaceService
         }
         catch (JsonException) { return null; }
         catch (KeyNotFoundException) { return null; }
+        catch (InvalidOperationException) { return null; }
+    }
+
+    private WorkspaceMetadata? ReadMetadata(string directory, string expectedId)
+    {
+        var path = Path.Combine(directory, MetadataFile);
+        if (!File.Exists(path))
+            return null;
+        try
+        {
+            var metadata = JsonSerializer.Deserialize<WorkspaceMetadata>(
+                File.ReadAllText(path), _json);
+            if (metadata is null || string.IsNullOrWhiteSpace(metadata.Id) ||
+                !metadata.Id.Equals(expectedId, StringComparison.Ordinal))
+                return null;
+            WorkspaceNameValidator.Validate(metadata.Id);
+            return metadata;
+        }
+        catch (JsonException) { return null; }
+        catch (UnauthorizedAccessException) { return null; }
         catch (InvalidOperationException) { return null; }
     }
 

--- a/CoffeeTalk.Gui/CoffeeTalk.Gui.csproj
+++ b/CoffeeTalk.Gui/CoffeeTalk.Gui.csproj
@@ -18,4 +18,11 @@
     <ProjectReference Include="..\CoffeeTalk.Core\CoffeeTalk.Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Update="wwwroot\**">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+  </ItemGroup>
+
 </Project>

--- a/CoffeeTalk.Gui/Components/MainLayout.razor
+++ b/CoffeeTalk.Gui/Components/MainLayout.razor
@@ -3,6 +3,7 @@
 @namespace CoffeeTalk.Gui.Components
 
 <MudThemeProvider @ref="_mudThemeProvider" @bind-IsDarkMode="_isDarkMode" Theme="_theme" />
+<MudPopoverProvider />
 <MudDialogProvider />
 <MudSnackbarProvider />
 

--- a/CoffeeTalk.Gui/Components/Pages/Conversation.razor
+++ b/CoffeeTalk.Gui/Components/Pages/Conversation.razor
@@ -54,7 +54,7 @@
     </MudPaper>
 }
 
-<MudGrid Style="height: calc(100vh - 145px);">
+<MudGrid Class="conversation-grid" Style="height: calc(100vh - 145px);">
     <MudItem xs="12" md="4" Class="d-flex flex-column" Style="height: 100%;">
         <MudPaper Elevation="4" Class="d-flex flex-column flex-grow-1 overflow-hidden">
             <MudToolBar Dense="true" Class="mud-theme-primary">
@@ -80,12 +80,12 @@
     </MudItem>
 
     <MudItem xs="12" md="8" Class="d-flex flex-column" Style="height: 100%;">
-        <MudPaper Elevation="4" Class="d-flex flex-column flex-grow-1 overflow-hidden">
+        <MudPaper Elevation="4" Class="chat-panel d-flex flex-column flex-grow-1 overflow-hidden">
             @if (!string.IsNullOrEmpty(UI.StatusMessage))
             {
                 <MudAlert Severity="Severity.Info" Dense="true" Class="rounded-0">@UI.StatusMessage</MudAlert>
             }
-            <div class="flex-grow-1 overflow-y-auto pa-4" id="chat-container">
+            <div class="chat-container flex-grow-1 overflow-y-auto pa-4" id="chat-container">
                 @foreach (var msg in UI.GetMessagesSnapshot())
                 {
                     if (msg.IsDivider)
@@ -96,10 +96,21 @@
                             <MudText Align="Align.Center" Color="Color.Secondary" Typo="Typo.caption" Class="d-block mb-2">@msg.Content</MudText>
                         }
                     }
+                    else if (msg.IsTelemetry)
+                    {
+                        <div class="telemetry-row telemetry-@msg.TelemetryCategory">
+                            <span class="telemetry-time">@FormatTimestamp(msg.Timestamp)</span>
+                            <span class="telemetry-label">@GetTelemetryLabel(msg.TelemetryCategory)</span>
+                            <span class="telemetry-content">@msg.Content</span>
+                        </div>
+                    }
                     else if (msg.IsSystem)
                     {
-                        <div class="d-flex justify-center mb-2">
-                            <MudChip T="string" Color="Color.Info" Size="Size.Small" Variant="Variant.Text">@msg.Content</MudChip>
+                        <div class="system-message timeline-event">
+                            <MudPaper Class="system-message-panel pa-3" Elevation="0">
+                                <div class="timeline-event-meta">@FormatTimestamp(msg.Timestamp) · request timeline</div>
+                                <div class="message-content">@((MarkupString)RenderMarkdown(msg.Content))</div>
+                            </MudPaper>
                         </div>
                     }
                     else if (msg.IsError)
@@ -162,6 +173,11 @@
         UI.OnChange += OnUiChanged;
     }
 
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        await RenderMermaidAsync();
+    }
+
     public void Dispose()
     {
         _disposed = true;
@@ -170,6 +186,15 @@
     }
 
     private void StopConversation() => Session.Cancel();
+
+    private static string GetTelemetryLabel(string? category) => category switch
+    {
+        "thinking" => "thinking",
+        "started" => "request",
+        "completed" => "done",
+        "failed" => "failed",
+        _ => "event"
+    };
     private void Submit(string action, string message)
     {
         if (action == "quit")
@@ -194,6 +219,7 @@
                 return;
 
             StateHasChanged();
+            await RenderMermaidAsync();
             await ScrollToBottomAsync(scrollCancellationToken);
         });
         _ = ObserveRenderTaskAsync(renderTask, scrollCancellationToken);
@@ -224,6 +250,22 @@
         }
         catch (JSException) { }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { }
+    }
+
+    private async Task RenderMermaidAsync()
+    {
+        if (!UI.DocumentMarkdown.Contains("```mermaid", StringComparison.OrdinalIgnoreCase) &&
+            !UI.GetMessagesSnapshot().Any(message =>
+                message.Content.Contains("```mermaid", StringComparison.OrdinalIgnoreCase)))
+        {
+            return;
+        }
+
+        try
+        {
+            await JSRuntime.InvokeVoidAsync("renderMermaid");
+        }
+        catch (JSException) { }
     }
 
     private async Task SaveChat()
@@ -401,6 +443,20 @@
     {
         if (string.IsNullOrWhiteSpace(markdown))
             return "";
-        return ConversationExportService.RenderMarkdown(markdown);
+        return ConversationExportService.RenderMarkdown(RemoveConsoleMarkup(markdown));
+    }
+
+    private static string RemoveConsoleMarkup(string text)
+    {
+        foreach (var tag in new[]
+        {
+            "[bold]", "[/]", "[yellow]", "[green]", "[magenta]", "[dim]",
+            "[bold green]", "[bold red]"
+        })
+        {
+            text = text.Replace(tag, string.Empty, StringComparison.OrdinalIgnoreCase);
+        }
+
+        return text;
     }
 }

--- a/CoffeeTalk.Gui/Components/Pages/Home.razor
+++ b/CoffeeTalk.Gui/Components/Pages/Home.razor
@@ -73,10 +73,11 @@
                     <MudText Typo="Typo.caption" Class="mb-2 d-block">Choose at least two personas.</MudText>
 
                     <MudPaper Class="pa-4" Outlined="true">
-                        <MudChipSet T="object" MultiSelection="true" @bind-SelectedValues="SelectedPersonas" CheckMark="true">
+                        <MudChipSet T="PersonaConfig" SelectionMode="SelectionMode.MultiSelection"
+                                    @bind-SelectedValues="SelectedPersonas" CheckMark="true">
                             @foreach (var persona in AppState.Settings.Personas)
                             {
-                                <MudChip T="object" Value="@((object)persona)" Text="@persona.Name" Color="Color.Primary" Variant="Variant.Text" SelectedColor="Color.Primary" />
+                                <MudChip T="PersonaConfig" Value="@persona" Text="@persona.Name" Color="Color.Primary" Variant="Variant.Text" SelectedColor="Color.Primary" />
                             }
                         </MudChipSet>
                     </MudPaper>
@@ -121,16 +122,30 @@
 @code {
     private string Topic = "";
 
-    private IReadOnlyCollection<object> SelectedPersonas { get; set; } = new List<object>();
+    private IReadOnlyCollection<PersonaConfig> SelectedPersonas { get; set; } = Array.Empty<PersonaConfig>();
     private IReadOnlyList<ConversationRecord> _recentConversations = Array.Empty<ConversationRecord>();
     private IReadOnlyList<WorkspaceMetadata> _workspaces = Array.Empty<WorkspaceMetadata>();
 
-    protected override async Task OnInitializedAsync()
+    protected override void OnInitialized()
     {
         // Select all by default
-        SelectedPersonas = AppState.Settings.Personas.Cast<object>().ToList();
+        SelectedPersonas = AppState.Settings.Personas.ToList();
+    }
+
+    protected override Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender)
+            return Task.CompletedTask;
+
+        _ = LoadStartupDataAsync();
+        return Task.CompletedTask;
+    }
+
+    private async Task LoadStartupDataAsync()
+    {
         _recentConversations = await History.RecentAsync();
         _workspaces = await AppState.ListWorkspacesAsync();
+        await InvokeAsync(StateHasChanged);
     }
 
     private void StartConversation()
@@ -138,7 +153,7 @@
         if (string.IsNullOrWhiteSpace(Topic)) return;
         if (SelectedPersonas == null || SelectedPersonas.Count < 2) return;
 
-        Session.Start(Topic, SelectedPersonas.Cast<PersonaConfig>().ToList());
+        Session.Start(Topic, SelectedPersonas);
         Navigation.NavigateTo("/conversation");
     }
 
@@ -159,7 +174,7 @@
         }
         await AppState.SwitchWorkspaceAsync(id);
         _workspaces = await AppState.ListWorkspacesAsync();
-        SelectedPersonas = AppState.Settings.Personas.Cast<object>().ToList();
+        SelectedPersonas = AppState.Settings.Personas.ToList();
         _recentConversations = await History.RecentAsync();
     }
 }

--- a/CoffeeTalk.Gui/Program.cs
+++ b/CoffeeTalk.Gui/Program.cs
@@ -1,5 +1,6 @@
 using Photino.Blazor;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using CoffeeTalk.Services;
 using CoffeeTalk.Gui.Services;
 using CoffeeTalk.Core.Interfaces;
@@ -14,7 +15,8 @@ class Program
     {
         var appBuilder = PhotinoBlazorAppBuilder.CreateDefault(args);
 
-        appBuilder.Services.AddLogging();
+        appBuilder.Services.AddLogging(logging =>
+            logging.AddConsole().SetMinimumLevel(LogLevel.Information));
         appBuilder.Services.AddSingleton<ApplicationDataPathResolver>();
         appBuilder.Services.AddSingleton<IApplicationDataPathResolver>(sp => sp.GetRequiredService<ApplicationDataPathResolver>());
         appBuilder.Services.AddSingleton<IWorkspacePathResolver>(sp => sp.GetRequiredService<ApplicationDataPathResolver>());
@@ -40,15 +42,17 @@ class Program
 
         // Try using the type directly if possible, or fully qualified.
         // Since App is in CoffeeTalk.Gui.Components namespace.
-        appBuilder.RootComponents.Add<CoffeeTalk.Gui.Components.App>("#app");
+        appBuilder.RootComponents.Add<CoffeeTalk.Gui.Components.App>("app");
 
         var app = appBuilder.Build();
+
+        AppDomain.CurrentDomain.UnhandledException += (_, error) =>
+            app.MainWindow.ShowMessage("CoffeeTalk startup error", error.ExceptionObject?.ToString() ?? "Unknown error");
 
         app.MainWindow
             .SetTitle("CoffeeTalk GUI")
             .SetUseOsDefaultSize(false)
-            .SetSize(1024, 768)
-            .SetIconFile("favicon.ico"); // Optional
+            .SetSize(1024, 768);
 
         app.Run();
     }

--- a/CoffeeTalk.Gui/Services/BlazorOperationalEventSink.cs
+++ b/CoffeeTalk.Gui/Services/BlazorOperationalEventSink.cs
@@ -53,9 +53,57 @@ public sealed class BlazorOperationalEventSink : IOperationalEventSink
                 (string.IsNullOrWhiteSpace(operationalEvent.Reason) ? string.Empty : $" ({operationalEvent.Reason})"),
             OperationalEventKind.OperationFailure =>
                 $"{operationalEvent.Operation} failed.",
+            OperationalEventKind.RequestStarted =>
+                $"Started {operationalEvent.Operation} [{operationalEvent.RequestId}] — context ~{operationalEvent.EstimatedPromptTokens} tokens ({operationalEvent.PromptCharacters} chars).",
+            OperationalEventKind.RequestThinking =>
+                $"Thinking {operationalEvent.Operation} [{operationalEvent.RequestId}]: {operationalEvent.Reason}",
+            OperationalEventKind.RequestCompleted =>
+                $"Completed {operationalEvent.Operation} [{operationalEvent.RequestId}] in {FormatDuration(operationalEvent.DurationMilliseconds)} — first output {FormatDuration(operationalEvent.FirstTokenMilliseconds)}, context {FormatTokenCount(operationalEvent.InputTokens, operationalEvent.EstimatedPromptTokens)} tokens, output {FormatTokenCount(operationalEvent.OutputTokens, operationalEvent.EstimatedOutputTokens)} tokens ({operationalEvent.OutputCharacters} chars), total {FormatTokenCount(operationalEvent.TotalTokens, null)}.",
+            OperationalEventKind.RequestFailed =>
+                $"Failed {operationalEvent.Operation} [{operationalEvent.RequestId}] after {FormatDuration(operationalEvent.DurationMilliseconds)} — {operationalEvent.Reason}",
+            OperationalEventKind.ToolStarted =>
+                $"Tool started {operationalEvent.Operation} [{operationalEvent.RequestId}] — arguments {operationalEvent.ArgumentCharacters} chars.",
+            OperationalEventKind.ToolCompleted =>
+                $"Tool completed {operationalEvent.Operation} [{operationalEvent.RequestId}] in {FormatDuration(operationalEvent.DurationMilliseconds)} — result {operationalEvent.ResultCharacters} chars.",
+            OperationalEventKind.ToolFailed =>
+                $"Tool failed {operationalEvent.Operation} [{operationalEvent.RequestId}] after {FormatDuration(operationalEvent.DurationMilliseconds)} — {operationalEvent.Reason}",
             _ => throw new ArgumentOutOfRangeException(nameof(operationalEvent), operationalEvent.Kind, "Unknown operational event kind.")
         };
 
-        _ui.ShowMessageAsync(message).GetAwaiter().GetResult();
+        if (operationalEvent.Kind is OperationalEventKind.RequestStarted
+            or OperationalEventKind.RequestThinking
+            or OperationalEventKind.RequestCompleted
+            or OperationalEventKind.RequestFailed
+            or OperationalEventKind.ToolStarted
+            or OperationalEventKind.ToolCompleted
+            or OperationalEventKind.ToolFailed)
+        {
+            var category = operationalEvent.Kind switch
+            {
+                OperationalEventKind.RequestStarted => "started",
+                OperationalEventKind.RequestThinking => "thinking",
+                OperationalEventKind.RequestCompleted => "completed",
+                OperationalEventKind.RequestFailed => "failed",
+                OperationalEventKind.ToolStarted => "started",
+                OperationalEventKind.ToolCompleted => "completed",
+                OperationalEventKind.ToolFailed => "failed",
+                _ => "event"
+            };
+            _ = _ui.ShowTelemetryAsync(operationalEvent.RequestId ?? "unknown", category, message);
+        }
+        else
+        {
+            _ = _ui.ShowMessageAsync(message);
+        }
     }
+
+    private static string FormatDuration(long? milliseconds) =>
+        milliseconds is null
+            ? "n/a"
+            : milliseconds < 1000
+                ? $"{milliseconds}ms"
+                : $"{milliseconds.Value / 1000d:0.0}s";
+
+    private static string FormatTokenCount(long? actual, int? estimate) =>
+        actual is not null ? $"{actual} actual" : $"~{estimate} estimated";
 }

--- a/CoffeeTalk.Gui/Services/BlazorUserInterface.cs
+++ b/CoffeeTalk.Gui/Services/BlazorUserInterface.cs
@@ -1,6 +1,5 @@
 using CoffeeTalk.Core.Interfaces;
 using Microsoft.AspNetCore.Components;
-using Markdig;
 
 namespace CoffeeTalk.Gui.Services
 {
@@ -33,12 +32,7 @@ namespace CoffeeTalk.Gui.Services
         // Document State
         public string DocumentContent { get; private set; } = "";
         public string DocumentMarkdown { get; private set; } = "";
-        public string DocumentHtml => Markdown.ToHtml(DocumentMarkdown, MarkdownPipeline);
-
-        private static readonly MarkdownPipeline MarkdownPipeline = new MarkdownPipelineBuilder()
-            .DisableHtml()
-            .UseAdvancedExtensions()
-            .Build();
+        public string DocumentHtml => ConversationExportService.RenderMarkdown(DocumentMarkdown);
 
         // User Intervention
         private readonly object _tcsLock = new();
@@ -59,6 +53,34 @@ namespace CoffeeTalk.Gui.Services
         {
             lock (_messagesLock)
                 Messages.Add(new ChatMessage { Sender = "Error", Content = message, IsError = true });
+            NotifyStateChanged();
+            return Task.CompletedTask;
+        }
+
+        public Task ShowTelemetryAsync(string requestId, string category, string message)
+        {
+            lock (_messagesLock)
+            {
+                var previous = Messages.LastOrDefault();
+                if (category == "thinking" &&
+                    previous is { IsTelemetry: true, TelemetryRequestId: not null } &&
+                    previous.TelemetryRequestId == requestId &&
+                    previous.TelemetryCategory == category)
+                {
+                    previous.Content += message;
+                }
+                else
+                {
+                    Messages.Add(new ChatMessage
+                    {
+                        Sender = "Telemetry",
+                        Content = message,
+                        IsTelemetry = true,
+                        TelemetryRequestId = requestId,
+                        TelemetryCategory = category
+                    });
+                }
+            }
             NotifyStateChanged();
             return Task.CompletedTask;
         }
@@ -235,6 +257,19 @@ namespace CoffeeTalk.Gui.Services
             NotifyStateChanged();
         }
 
+        public void BeginConversation(string topic, IReadOnlyCollection<string> participants)
+        {
+            ConversationTopic = topic;
+            ConversationParticipants = participants.ToList();
+            ConversationMode = "Preparing";
+            ConversationStartedAt = DateTime.Now;
+            IsConversationRunning = true;
+            StopRequested = false;
+            IsBusy = true;
+            StatusMessage = "Preparing conversation...";
+            NotifyStateChanged();
+        }
+
         public void LoadConversation(ConversationRecord record)
         {
             lock (_messagesLock)
@@ -248,6 +283,9 @@ namespace CoffeeTalk.Gui.Services
                     IsSystem = message.IsSystem,
                     IsError = message.IsError,
                     IsDivider = message.IsDivider,
+                    IsTelemetry = message.IsTelemetry,
+                    TelemetryRequestId = message.TelemetryRequestId,
+                    TelemetryCategory = message.TelemetryCategory,
                     Timestamp = message.Timestamp
                 }));
             }
@@ -286,6 +324,9 @@ namespace CoffeeTalk.Gui.Services
         public bool IsSystem { get; set; }
         public bool IsError { get; set; }
         public bool IsDivider { get; set; }
+        public bool IsTelemetry { get; set; }
+        public string? TelemetryRequestId { get; set; }
+        public string? TelemetryCategory { get; set; }
         public DateTime Timestamp { get; set; } = DateTime.Now;
     }
 }

--- a/CoffeeTalk.Gui/Services/ConversationExportService.cs
+++ b/CoffeeTalk.Gui/Services/ConversationExportService.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using Markdig;
 using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
+using System.Text.RegularExpressions;
 
 namespace CoffeeTalk.Gui.Services;
 
@@ -27,7 +28,12 @@ public static class ConversationExportService
                 link.Url = null;
         }
 
-        return Markdig.Markdown.ToHtml(document, MarkdownPipeline);
+        var html = Markdig.Markdown.ToHtml(document, MarkdownPipeline);
+        return Regex.Replace(
+            html,
+            "<pre><code class=\"language-mermaid\">(?<diagram>.*?)</code></pre>",
+            "<div class=\"mermaid\">${diagram}</div>",
+            RegexOptions.Singleline | RegexOptions.CultureInvariant);
     }
 
     public static string GenerateMarkdown(

--- a/CoffeeTalk.Gui/Services/ConversationSessionService.cs
+++ b/CoffeeTalk.Gui/Services/ConversationSessionService.cs
@@ -1,6 +1,7 @@
 using CoffeeTalk.Models;
 using CoffeeTalk.Services;
 using Microsoft.Extensions.Logging;
+using System.Diagnostics;
 
 namespace CoffeeTalk.Gui.Services;
 
@@ -51,6 +52,10 @@ public sealed class ConversationSessionService : IConversationSessionService, ID
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(topic);
         ArgumentNullException.ThrowIfNull(personas);
+        _logger.LogInformation(
+            "Starting conversation for topic {Topic} with personas {Personas}",
+            topic,
+            string.Join(", ", personas.Select(persona => persona.Name)));
 
         CancellationTokenSource cts;
         Task? previousTask;
@@ -62,6 +67,7 @@ public sealed class ConversationSessionService : IConversationSessionService, ID
             cts = _cts = new CancellationTokenSource();
             _conversationTask = RunAfterPreviousAsync(previousTask, topic, personas.ToList(), cts);
         }
+        _ui.BeginConversation(topic, personas.Select(persona => persona.Name).ToList());
         _ui.CancelIntervention(false);
     }
 
@@ -130,10 +136,19 @@ public sealed class ConversationSessionService : IConversationSessionService, ID
 
     private async Task RunAsync(string topic, List<PersonaConfig> personas, CancellationTokenSource cts)
     {
+        var stopwatch = Stopwatch.StartNew();
         try
         {
+            _logger.LogInformation("Building conversation pipeline for {Topic}", topic);
             var pipeline = await _pipelineBuilder.BuildAsync(_appState.Settings, topic, personas, cts.Token);
+            _logger.LogInformation(
+                "Conversation pipeline built for {Topic}; orchestrator={HasOrchestrator}, personas={PersonaCount}",
+                topic,
+                pipeline.Orchestrator is not null,
+                pipeline.Personas.Count);
+            _logger.LogInformation("Entering agent conversation execution for {Topic}", topic);
             await pipeline.CreateConversation(_ui).StartConversationAsync(topic, cts.Token);
+            _logger.LogInformation("Agent conversation execution completed for {Topic}", topic);
         }
         catch (OperationCanceledException) when (cts.IsCancellationRequested)
         {
@@ -141,10 +156,15 @@ public sealed class ConversationSessionService : IConversationSessionService, ID
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error during conversation orchestration");
-            await _ui.ShowErrorAsync("An error occurred while starting the conversation. Please check your configuration and try again.");
+            await _ui.ShowErrorAsync($"Conversation failed: {ex.Message}");
         }
         finally
         {
+            _logger.LogInformation(
+                "Conversation task finished for {Topic} after {ElapsedSeconds:F1}s; cancelled={Cancelled}",
+                topic,
+                stopwatch.Elapsed.TotalSeconds,
+                cts.IsCancellationRequested);
             ConversationRecord? record = null;
             lock (_gate)
             {

--- a/CoffeeTalk.Gui/wwwroot/css/app.css
+++ b/CoffeeTalk.Gui/wwwroot/css/app.css
@@ -78,13 +78,32 @@ html, body {
     position: sticky;
     top: 0;
     z-index: 2;
+    border: 1px solid color-mix(in srgb, var(--mud-palette-primary) 18%, transparent);
+    background: linear-gradient(135deg, var(--mud-palette-surface), var(--mud-palette-background-gray));
+}
+
+.conversation-grid {
+    min-height: 0;
+    gap: .75rem 0;
+}
+
+.chat-panel {
+    min-width: 0;
+    border: 1px solid var(--mud-palette-divider);
+}
+
+.chat-container {
+    min-width: 0;
+    scroll-behavior: smooth;
+    background: color-mix(in srgb, var(--mud-palette-background) 82%, var(--mud-palette-primary) 18%);
 }
 
 .message-row {
     display: flex;
     flex-direction: column;
     margin-bottom: 1rem;
-    max-width: 86%;
+    width: min(86%, 52rem);
+    min-width: 0;
 }
 
 .message-row.align-end {
@@ -97,6 +116,71 @@ html, body {
     align-items: flex-start;
 }
 
+.system-message {
+    width: min(100%, 52rem);
+    margin: 0 auto 1rem;
+    min-width: 0;
+}
+
+.system-message-panel {
+    min-width: 0;
+    max-width: 100%;
+    overflow: hidden;
+    color: var(--mud-palette-text-secondary);
+    background: color-mix(in srgb, var(--mud-palette-info-lighten) 35%, var(--mud-palette-surface));
+    border: 1px solid color-mix(in srgb, var(--mud-palette-info) 25%, transparent);
+}
+
+.timeline-event-meta {
+    color: var(--mud-palette-text-secondary);
+    font-size: .72rem;
+    letter-spacing: .02em;
+    margin-bottom: .3rem;
+}
+
+.telemetry-row {
+    display: flex;
+    align-items: baseline;
+    gap: .45rem;
+    width: min(100%, 58rem);
+    margin: .2rem auto;
+    padding: .28rem .55rem;
+    border-left: 2px solid var(--mud-palette-divider);
+    color: var(--mud-palette-text-secondary);
+    font: .76rem/1.35 ui-monospace, SFMono-Regular, Menlo, monospace;
+    overflow-wrap: anywhere;
+}
+
+.telemetry-time {
+    flex: 0 0 auto;
+    opacity: .7;
+}
+
+.telemetry-label {
+    flex: 0 0 auto;
+    min-width: 4.8rem;
+    color: var(--mud-palette-primary);
+    font-weight: 600;
+}
+
+.telemetry-content {
+    min-width: 0;
+}
+
+.telemetry-thinking {
+    border-left-color: var(--mud-palette-warning);
+    background: color-mix(in srgb, var(--mud-palette-warning-lighten) 12%, transparent);
+}
+
+.telemetry-completed {
+    border-left-color: var(--mud-palette-success);
+}
+
+.telemetry-failed {
+    border-left-color: var(--mud-palette-error);
+    color: var(--mud-palette-error);
+}
+
 .message-meta {
     display: flex;
     align-items: center;
@@ -106,6 +190,78 @@ html, body {
 
 .message-bubble {
     background-color: var(--mud-palette-surface);
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+    overflow: hidden;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, .06);
+}
+
+.message-content {
+    min-width: 0;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    line-height: 1.55;
+}
+
+.message-content p {
+    margin: 0 0 .7rem;
+}
+
+.message-content p:last-child {
+    margin-bottom: 0;
+}
+
+.message-content ul,
+.message-content ol {
+    padding-left: 1.35rem;
+    margin: .35rem 0 .7rem;
+}
+
+.message-content blockquote {
+    margin: .6rem 0;
+    padding: .4rem .8rem;
+    border-left: 3px solid var(--mud-palette-primary);
+    color: var(--mud-palette-text-secondary);
+}
+
+.message-content pre {
+    max-width: 100%;
+    overflow-x: hidden;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+}
+
+.message-content code {
+    overflow-wrap: anywhere;
+    word-break: break-word;
+}
+
+.message-content table {
+    display: block;
+    max-width: 100%;
+    overflow-x: auto;
+}
+
+.message-content img,
+.message-content svg {
+    max-width: 100%;
+    height: auto;
+}
+
+.document-content .mermaid,
+.message-content .mermaid {
+    max-width: 100%;
+    overflow-x: auto;
+    padding: .75rem 0;
+    text-align: center;
+}
+
+.document-content .mermaid svg,
+.message-content .mermaid svg {
+    max-width: 100%;
+    height: auto;
 }
 
 .thinking-indicator {
@@ -128,6 +284,11 @@ html, body {
     padding: .75rem;
     border-radius: .35rem;
     background-color: var(--mud-palette-background-gray);
+}
+
+.document-content {
+    min-width: 0;
+    overflow-wrap: anywhere;
 }
 
 .document-content code {
@@ -153,4 +314,14 @@ html, body {
     border: 1px solid #ffeeba;
     margin-bottom: 10px;
     border-radius: 4px;
+}
+
+@media (max-width: 960px) {
+    .conversation-grid {
+        height: auto !important;
+    }
+
+    .message-row {
+        width: 94%;
+    }
 }

--- a/CoffeeTalk.Gui/wwwroot/index.html
+++ b/CoffeeTalk.Gui/wwwroot/index.html
@@ -11,10 +11,17 @@
     <link href="CoffeeTalk.Gui.styles.css" rel="stylesheet" />
 </head>
 <body>
-    <div id="app">Loading...</div>
+    <app>Loading...</app>
 
-    <script src="_framework/blazor.web.js"></script>
+    <div id="blazor-error-ui">
+        An unhandled error has occurred.
+        <a href="" class="reload">Reload</a>
+        <a class="dismiss">Dismiss</a>
+    </div>
+
+    <script src="_framework/blazor.webview.js"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>
     <script src="js/app.js"></script>
 </body>
 </html>

--- a/CoffeeTalk.Gui/wwwroot/js/app.js
+++ b/CoffeeTalk.Gui/wwwroot/js/app.js
@@ -4,3 +4,15 @@ window.scrollToBottom = (elementId) => {
         element.scrollTop = element.scrollHeight;
     }
 };
+
+window.renderMermaid = async () => {
+    if (!window.mermaid) {
+        return;
+    }
+
+    window.mermaid.initialize({ startOnLoad: false, securityLevel: 'strict', theme: 'default' });
+    const diagrams = document.querySelectorAll('.mermaid:not([data-processed="true"])');
+    if (diagrams.length > 0) {
+        await window.mermaid.run({ nodes: Array.from(diagrams) });
+    }
+};

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ☕ CoffeeTalk
 
-A .NET CLI application that orchestrates multi-persona LLM conversations using Microsoft Agent Framework. Configure multiple AI personas with unique system prompts and watch them engage in dynamic conversations to explore topics and reach conclusions through collaborative document creation.
+CoffeeTalk is a .NET 9 application for orchestrating multi-persona LLM conversations with Microsoft's Agent Framework. It includes a Photino/Blazor desktop GUI and a Spectre.Console CLI. Configure personas with distinct system prompts, let them collaborate on a shared Markdown document, inspect live request/tool telemetry, and require persona consensus before a conversation concludes.
 
 ## Features
 
@@ -16,10 +16,15 @@ A .NET CLI application that orchestrates multi-persona LLM conversations using M
 - **Retry Handling**: Automatic retry with exponential backoff for API rate limits (HTTP 429)
 - **Flexible Conversation Modes**: Choose between orchestrated (AI-directed) or round-robin (sequential) conversation flow
 - **Built on Microsoft Agent Framework**: Leverages Microsoft's Agent Framework for robust agentic AI integration
+- **Agent Threads**: Personas and the orchestrator retain framework-managed thread state across requests
+- **Full Document Context**: Personas and the orchestrator receive the current Markdown document, not only its headings
+- **Consensus Verification**: When the orchestrator proposes completion, every persona reviews the document and must agree
+- **Request and Tool Telemetry**: View prompt/output sizes, token usage, first-output latency, duration, failures, and document tool calls
+- **Mermaid Rendering**: Mermaid fenced blocks render in the GUI and exported Markdown previews
 
 ## Prerequisites
 
-- .NET 8.0 SDK or later
+- .NET 9.0 SDK
 - OpenAI API key (for OpenAI provider) or Ollama running locally
 
 ## Package Restoration
@@ -99,17 +104,24 @@ Edit `CoffeeTalk/appsettings.json` or use `appsettings.azureopenai.json` as a te
 cp CoffeeTalk/appsettings.ollama.json CoffeeTalk/appsettings.json
 ```
 
-### 3. Build and Run
+### 3. Build and Run the CLI
 
 ```bash
-cd CoffeeTalk
-dotnet build
-dotnet run
+dotnet build CoffeeTalk/CoffeeTalk.CLI.csproj
+dotnet run --project CoffeeTalk/CoffeeTalk.CLI.csproj
 ```
+
+To launch the desktop GUI:
+
+```bash
+dotnet run --project CoffeeTalk.Gui/CoffeeTalk.Gui.csproj
+```
+
+The GUI stores active workspace configuration and conversation data under the application data directory. The CLI loads the same workspace-oriented configuration model and also supports history, analytics, export, and memory commands.
 
 ### 4. Start a Conversation
 
-When prompted, enter a topic:
+In either interface, enter a topic when prompted. The GUI shows conversation messages, the live Markdown document, status updates, and compact telemetry rows. The CLI displays the conversation and operational events in the terminal.
 
 ```
 What would you like the personas to discuss?
@@ -120,7 +132,7 @@ Watch the personas engage in a multi-perspective discussion and collaboratively 
 
 ### 5. Review the Output
 
-The conversation is auto-saved to `conversation.md` in the CoffeeTalk directory.
+The shared document is auto-saved to the active workspace. The CLI can additionally persist conversation history with `--save` and export the document with `--export-format`.
 
 ## Configuration
 
@@ -415,13 +427,29 @@ Personas can collaborate on a shared markdown document using these tools:
 - `AppendParagraph`: Add content to the document
 - `InsertAfterHeading`: Insert content under a specific heading
 - `ListHeadings`: View current document structure
+- `ReplaceSection`: Replace the content under a heading
+- `SaveDocument`: Persist the current document
 
-The document is maintained in memory during the conversation and auto-saved to `conversation.md` when complete.
+The document is shared and locked across agents. Personas, the orchestrator, and optional editor/fact-checking agents receive the current full Markdown snapshot. The GUI refreshes the document while responses stream, and Mermaid blocks are rendered in the preview.
+
+The document is maintained in memory during the conversation and auto-saved to the active workspace when complete.
 
 ### Additional Settings
 
 - **MaxConversationTurns**: Maximum number of conversation rounds (default: 10). This is multiplied by the number of personas in round-robin mode, or used as a total turn limit in orchestrated mode.
 - **ShowThinking**: Display thinking indicators during responses (default: true). When enabled, you see `💭 Thinking...` while the LLM processes.
+- **StreamingEnabled**: Enable streaming responses when the provider supports it (default: true)
+- **StreamingFallback**: Use `"buffered"` when streaming is unavailable, or `"error"` to fail instead
+
+### Request and tool telemetry
+
+The active event sink records each LLM and document-tool operation. Events include a request or tool ID, operation name, prompt/argument size, output/result size, estimated tokens, provider-reported usage when available, first-output latency, total duration, completion, and failure details. The GUI groups these events into compact timeline rows; the CLI writes them to the terminal. Streaming reasoning chunks are surfaced as thinking events when the provider exposes them.
+
+Telemetry measures the application payload passed to the Agent Framework. Providers may add system instructions and thread history, so provider-reported input usage can be larger than the application estimate.
+
+### Consensus verification
+
+Consensus verification applies to orchestrated mode. When the orchestrator returns its completion signal, CoffeeTalk asks every configured persona to review the full document and recent discussion concurrently. Each persona must return `CONSENSUS: YES` or `CONSENSUS: NO` with a short reason. The conversation ends only when all personas agree; dissenting reasons are sent back to the orchestrator as the next follow-up message. A failed or malformed consensus check is treated as a request to revise rather than as agreement.
 
 ## Usage Examples
 
@@ -679,7 +707,7 @@ Or use Ollama for unlimited local usage.
 ## Project Structure
 
 ```
-CoffeeTalk/
+CoffeeTalk.Core/
 ├── Models/
 │   ├── AppSettings.cs               # Main configuration model
 │   ├── LlmProviderConfig.cs         # LLM provider settings
@@ -699,14 +727,14 @@ CoffeeTalk/
 │   ├── AgentBuilder.cs              # Builds AIAgent instances for different providers
 │   ├── CollaborativeMarkdownDocument.cs  # Shared document state
 │   ├── MarkdownToolFunctions.cs     # Document editing tools as AIFunctions
+│   ├── RequestTelemetry.cs           # LLM request lifecycle telemetry
+│   ├── ToolTelemetry.cs              # Document tool lifecycle telemetry
 │   ├── RateLimiter.cs               # Request/token throttling
 │   └── RetryHandler.cs              # HTTP 429 retry logic
-├── appsettings.json                 # Default configuration
-├── appsettings.orchestrated.json    # Orchestrated mode example
-├── appsettings.azureopenai.json     # Azure OpenAI example
-├── appsettings.ollama.json          # Ollama example
-├── conversation.md                  # Auto-saved conversation output
-└── Program.cs                       # Application entry point
+├── CoffeeTalk.Gui/                  # Photino/Blazor desktop application
+├── CoffeeTalk/                      # Spectre.Console CLI
+├── CoffeeTalk.Tests/                # Unit and component tests
+└── examples/                        # Ready-to-use configurations
 
 examples/
 ├── product-team.json                # Product development team personas
@@ -828,7 +856,7 @@ examples/
 ### Round-Robin Mode (Default)
 
 1. **Initialization**: The application loads configuration from `appsettings.json`
-2. **Kernel Setup**: A Semantic Kernel instance is created with the configured LLM provider
+2. **Agent Setup**: Microsoft Agent Framework agents and persona threads are created with the configured LLM provider
 3. **Persona Creation**: Each persona is initialized with its unique system prompt
 4. **Tool Verification**: The system verifies that personas can use markdown collaboration tools
 5. **Conversation Loop**:
@@ -837,7 +865,7 @@ examples/
    - Each response builds on the conversation history and document state
    - Personas use tools to collaboratively edit the shared markdown document
    - Conversation continues until a conclusion is reached or max turns are hit
-6. **Auto-Save**: The collaborative document is saved to `conversation.md`
+6. **Auto-Save**: The collaborative document is saved to the active workspace
 
 ### Orchestrated Mode
 
@@ -854,7 +882,7 @@ examples/
    - Conversation adapts to needs (structure → content → refinement → conclusion)
    - No rigid turn order
    - Better token efficiency
-5. **Completion Detection**: Orchestrator recognizes when goals are achieved
+5. **Completion Proposal**: Orchestrator signals when it believes the goals are achieved, then all personas verify consensus
 
 ## Further Reading
 
@@ -883,7 +911,7 @@ MIT License - see [LICENSE](LICENSE) file for details.
 
 Built with:
 - [Microsoft Agent Framework](https://github.com/microsoft/agent-framework) - AI agent orchestration framework
-- [.NET 8](https://dotnet.microsoft.com/) - Runtime platform
+- [.NET 9](https://dotnet.microsoft.com/) - Runtime platform
 
 ## Support
 


### PR DESCRIPTION
## Summary

This PR captures the CoffeeTalk conversation reliability, Agent Framework alignment, observability, document rendering, consensus, and documentation improvements made during the debugging work.

## Changes

### Startup and GUI reliability
- Corrected Photino/Blazor bootstrapping, root selectors, static asset copying, favicon handling, and startup diagnostics.
- Restored normal routing and MudBlazor popover support.
- Removed constructor-time sync-over-async workspace metadata loading that could deadlock startup.
- Added clearer conversation preparation, lifecycle, cancellation, timeout, and failure reporting.
- Removed synchronous GUI event dispatch in conversation flows.

### Agent Framework integration
- Honored custom OpenAI-compatible endpoints, including unauthenticated local providers.
- Added lazy per-agent `AgentThread` usage for personas and the orchestrator.
- Preserved compatibility with test doubles and custom agents that do not support threads.
- Kept model calls serialized in the conversation pipeline while making the request lifecycle explicit.

### Request and tool telemetry
- Added request telemetry for persona generation, orchestrator selection, persona responses, streaming output, and consensus checks.
- Captured request IDs, prompt/output sizes, estimated and provider-reported token usage, first-output latency, total duration, completion, and failures.
- Added tool telemetry for Markdown document operations, including argument/result sizes, duration, completion, and failures.
- Added compact timeline rows for started, thinking, completed, failed, and tool-call events.
- Grouped consecutive thinking chunks by request for a compact modern agent-style UI.

### Conversation and document behavior
- Included the complete Markdown document in persona and orchestrator context instead of headings only.
- Refreshed the document preview during streaming and after agent/tool changes.
- Preserved full document snapshots for subsequent persona edits.
- Added Mermaid fenced-block conversion, Mermaid.js rendering, lifecycle refreshes, and responsive diagram styling.
- Improved wrapping and responsive rendering for chat content, code, tables, images, long tokens, and orchestrator notes.
- Corrected typed multi-persona selection and MudBlazor multi-selection configuration.

### Consensus verification
- When the orchestrator proposes completion, all personas independently review the full document and recent discussion.
- Consensus checks run concurrently to avoid unnecessary serial latency.
- Each persona returns a structured `CONSENSUS: YES` or `CONSENSUS: NO` assessment with a rationale.
- The conversation concludes only when all personas agree.
- Dissenting concerns are displayed in the timeline and fed back to the orchestrator for another contribution.
- Consensus request telemetry is included in the same visible timeline.

### Documentation
- Updated `README.md` to describe the current .NET 9 project structure, CLI and Photino/Blazor GUI entry points, workspace configuration, Agent Framework threads, full-document context, streaming fallback behavior, telemetry, Mermaid rendering, consensus verification, and current auto-save behavior.
- Removed stale references to .NET 8, Semantic Kernel, and the previous CLI-only architecture.

## Validation

- `dotnet test --no-restore --verbosity minimal`
- Result: 99 passed, 0 failed